### PR TITLE
feat: Allow a configurable basepath

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,9 @@ provider netbox {
   # Environment variable NETBOX_URL
   url = "127.0.0.1:8000"
 
+  # Environment variable NETBOX_BASEPATH
+  basepath = "/api"
+
   # Environment variable NETBOX_TOKEN
   token = "c07a2db4adb8b1e7f75e7c4369964e92f7680512"
 
@@ -25,5 +28,6 @@ provider netbox {
 ## Argument Reference
 
 * `url` or `NETBOX_URL` environment variable to define the URL and the port (127.0.0.1:8000 by default)
+* `basepath` or `NETBOX_BASEPATH` environment variable to define the base path (/api)
 * `token` or `NETBOX_TOKEN` environment variable to define the TOKEN to access the application (empty by default)
 * `scheme` or `NETBOX_SCHEME` environment variable to define the SCHEME of the URL (https by default)

--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -22,6 +22,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("NETBOX_URL", "127.0.0.1:8000"),
 				Description: "URL to reach netbox application.",
 			},
+			"basepath": {
+				Type:        schema.TypeString,
+				Required:    false,
+				DefaultFunc: schema.EnvDefaultFunc("NETBOX_BASEPATH", client.DefaultBasePath),
+				Description: "URL path to the netbox API.",
+			},
 			"token": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -133,12 +139,13 @@ func Provider() *schema.Provider {
 
 func configureProvider(d *schema.ResourceData) (interface{}, error) {
 	url := d.Get("url").(string)
+	basepath := d.Get("basepath").(string)
 	token := d.Get("token").(string)
 	scheme := d.Get("scheme").(string)
 
 	defaultScheme := []string{scheme}
 
-	t := runtimeclient.New(url, client.DefaultBasePath, defaultScheme)
+	t := runtimeclient.New(url, basepath, defaultScheme)
 	t.DefaultAuthentication = runtimeclient.APIKeyAuth(authHeaderName, "header",
 		fmt.Sprintf(authHeaderFormat, token))
 	return client.New(t, strfmt.Default), nil


### PR DESCRIPTION
Fixes: #48 

* Pretty much as it says. Note: I haven't successfully tested this due to (what I suspect) version differences. 
* Allows for netbox running behind some url prefix. Should be backwards compatible.
--- 

Note: still have some yaks to shave here to confirm it's working, my install is currently < 2.8, but this was an obvious first thing we would need here.