### PR TITLE
feat: Add default importer function to resources

### DIFF
--- a/docs/resources/ipam_aggregate.md
+++ b/docs/resources/ipam_aggregate.md
@@ -49,3 +49,11 @@ The ``tag`` block supports:
 
 In addition to the above arguments, the following attributes are exported:
 * ``id`` - The id (ref in Netbox) of this object.
+
+## Import
+
+Aggregates can be imported by `id` e.g.
+
+```
+$ terraform import netbox_ipam_aggregate.aggregate_test id
+```

--- a/docs/resources/ipam_ip_addresses.md
+++ b/docs/resources/ipam_ip_addresses.md
@@ -58,3 +58,11 @@ The ``tag`` block supports:
 
 In addition to the above arguments, the following attributes are exported:
 * ``id`` - The id (ref in Netbox) of this object.
+
+## Import
+
+Ip addresses can be imported by `id` e.g.
+
+```
+$ terraform import netbox_ipam_ip_addresses.ip_test id
+```

--- a/docs/resources/ipam_prefix.md
+++ b/docs/resources/ipam_prefix.md
@@ -42,3 +42,10 @@ The ``tag`` block supports:
 In addition to the above arguments, the following attributes are exported:
 * ``id`` - The id (ref in Netbox) of this object.
 
+## Import
+
+Prefixes can be imported by `id` e.g.
+
+```
+$ terraform import netbox_ipam_prefix.prefix_test id
+```

--- a/docs/resources/ipam_service.md
+++ b/docs/resources/ipam_service.md
@@ -55,3 +55,11 @@ The ``tag`` block supports:
 
 In addition to the above arguments, the following attributes are exported:
 * ``id`` - The id (ref in Netbox) of this object.
+
+## Import
+
+Services can be imported by `id` e.g.
+
+```
+$ terraform import netbox_ipam_service.service_test id
+```

--- a/docs/resources/ipam_vlan.md
+++ b/docs/resources/ipam_vlan.md
@@ -57,3 +57,11 @@ The ``tag`` block supports:
 
 In addition to the above arguments, the following attributes are exported:
 * ``id`` - The id (ref in Netbox) of this object.
+
+## Import
+
+Vlans can be imported by `id` e.g.
+
+```
+$ terraform import netbox_ipam_vlan.vlan_test id
+```

--- a/docs/resources/ipam_vlan_group.md
+++ b/docs/resources/ipam_vlan_group.md
@@ -23,3 +23,11 @@ The following arguments are supported:
 
 In addition to the above arguments, the following attributes are exported:
 * ``id`` - The id (ref in Netbox) of this object.
+
+## Import
+
+Vlan groups can be imported by `id` e.g.
+
+```
+$ terraform import netbox_ipam_vlan_group.vlan_group_test id
+```

--- a/docs/resources/tenancy_tenant.md
+++ b/docs/resources/tenancy_tenant.md
@@ -52,3 +52,11 @@ The ``tag`` block supports:
 
 In addition to the above arguments, the following attributes are exported:
 * ``id`` - The id (ref in Netbox) of this object.
+
+## Import
+
+Tenants can be imported by `id` e.g.
+
+```
+$ terraform import netbox_tenancy_tenant.tenant_test id
+```

--- a/docs/resources/tenancy_tenant_group.md
+++ b/docs/resources/tenancy_tenant_group.md
@@ -21,3 +21,11 @@ The following arguments are supported:
 
 In addition to the above arguments, the following attributes are exported:
 * ``id`` - The id (ref in Netbox) of this object.
+
+## Import
+
+Tenant groups can be imported by `id` e.g.
+
+```
+$ terraform import netbox_tenancy_tenant_group.tenant_group_test id
+```

--- a/docs/resources/virtualization_interface.md
+++ b/docs/resources/virtualization_interface.md
@@ -35,3 +35,11 @@ The ``tag`` block supports:
 
 In addition to the above arguments, the following attributes are exported:
 * ``id`` - The id (ref in Netbox) of this object.
+
+## Import
+
+Virtualization interfaces can be imported by `id` e.g.
+
+```
+$ terraform import netbox_virtualization_interface.interface_test id
+```

--- a/docs/resources/virtualization_vm.md
+++ b/docs/resources/virtualization_vm.md
@@ -57,3 +57,11 @@ The ``tag`` block supports:
 
 In addition to the above arguments, the following attributes are exported:
 * ``id`` - The id (ref in Netbox) of this object.
+
+## Import
+
+Virtualization vms can be imported by `id` e.g.
+
+```
+$ terraform import netbox_virtualization_vm.vm_test id
+```

--- a/netbox/resource_netbox_ipam_aggregate.go
+++ b/netbox/resource_netbox_ipam_aggregate.go
@@ -20,6 +20,9 @@ func resourceNetboxIpamAggregate() *schema.Resource {
 		Update: resourceNetboxIpamAggregateUpdate,
 		Delete: resourceNetboxIpamAggregateDelete,
 		Exists: resourceNetboxIpamAggregateExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"custom_fields": {

--- a/netbox/resource_netbox_ipam_ip_addresses.go
+++ b/netbox/resource_netbox_ipam_ip_addresses.go
@@ -19,6 +19,9 @@ func resourceNetboxIpamIPAddresses() *schema.Resource {
 		Update: resourceNetboxIpamIPAddressesUpdate,
 		Delete: resourceNetboxIpamIPAddressesDelete,
 		Exists: resourceNetboxIpamIPAddressesExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"address": {

--- a/netbox/resource_netbox_ipam_prefix.go
+++ b/netbox/resource_netbox_ipam_prefix.go
@@ -18,6 +18,9 @@ func resourceNetboxIpamPrefix() *schema.Resource {
 		Update: resourceNetboxIpamPrefixUpdate,
 		Delete: resourceNetboxIpamPrefixDelete,
 		Exists: resourceNetboxIpamPrefixExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"description": {

--- a/netbox/resource_netbox_ipam_service.go
+++ b/netbox/resource_netbox_ipam_service.go
@@ -18,6 +18,9 @@ func resourceNetboxIpamService() *schema.Resource {
 		Update: resourceNetboxIpamServiceUpdate,
 		Delete: resourceNetboxIpamServiceDelete,
 		Exists: resourceNetboxIpamServiceExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"custom_fields": {

--- a/netbox/resource_netbox_ipam_vlan.go
+++ b/netbox/resource_netbox_ipam_vlan.go
@@ -18,6 +18,9 @@ func resourceNetboxIpamVlan() *schema.Resource {
 		Update: resourceNetboxIpamVlanUpdate,
 		Delete: resourceNetboxIpamVlanDelete,
 		Exists: resourceNetboxIpamVlanExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"custom_fields": {

--- a/netbox/resource_netbox_ipam_vlan_group.go
+++ b/netbox/resource_netbox_ipam_vlan_group.go
@@ -19,6 +19,9 @@ func resourceNetboxIpamVlanGroup() *schema.Resource {
 		Update: resourceNetboxIpamVlanGroupUpdate,
 		Delete: resourceNetboxIpamVlanGroupDelete,
 		Exists: resourceNetboxIpamVlanGroupExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/netbox/resource_netbox_tenancy_tenant.go
+++ b/netbox/resource_netbox_tenancy_tenant.go
@@ -19,6 +19,9 @@ func resourceNetboxTenancyTenant() *schema.Resource {
 		Update: resourceNetboxTenancyTenantUpdate,
 		Delete: resourceNetboxTenancyTenantDelete,
 		Exists: resourceNetboxTenancyTenantExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"comments": {

--- a/netbox/resource_netbox_tenancy_tenant_group.go
+++ b/netbox/resource_netbox_tenancy_tenant_group.go
@@ -19,6 +19,9 @@ func resourceNetboxTenancyTenantGroup() *schema.Resource {
 		Update: resourceNetboxTenancyTenantGroupUpdate,
 		Delete: resourceNetboxTenancyTenantGroupDelete,
 		Exists: resourceNetboxTenancyTenantGroupExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/netbox/resource_netbox_virtualization_interface.go
+++ b/netbox/resource_netbox_virtualization_interface.go
@@ -19,6 +19,9 @@ func resourceNetboxVirtualizationInterface() *schema.Resource {
 		Update: resourceNetboxVirtualizationInterfaceUpdate,
 		Delete: resourceNetboxVirtualizationInterfaceDelete,
 		Exists: resourceNetboxVirtualizationInterfaceExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"description": {

--- a/netbox/resource_netbox_virtualization_vm.go
+++ b/netbox/resource_netbox_virtualization_vm.go
@@ -18,6 +18,9 @@ func resourceNetboxVirtualizationVM() *schema.Resource {
 		Update: resourceNetboxVirtualizationVMUpdate,
 		Delete: resourceNetboxVirtualizationVMDelete,
 		Exists: resourceNetboxVirtualizationVMExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"cluster_id": {


### PR DESCRIPTION
Fixes https://github.com/smutel/terraform-provider-netbox/issues/51

Tested with terraform 0.14.8 and 0.13.6 and netbox 3e4c35ffd9f6 (v2.10.6)
#### Tested ressources:

    ipam_aggreagate
    ipam_ip_addresses
    ipam_prefix
    ipam_service
    ipam_vlan
    ipam_vlan_group
    virtualization_interface
    virtualization_vm

#### Not tested:

    tenancy_tenant
    tenancy_tenant_group
