### PR TITLE
feat: netbox request params and provider argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Terraform provider for [Netbox.](https://netbox.readthedocs.io/en/stable/)
 
 ## Compatibility with Netbox
 
-Version 0.x.y => Netbox 2.8  
-Version 1.x.y => Netbox 2.9  
+Version 0.x.y => Netbox 2.8
+Version 1.x.y => Netbox 2.9
 
 ## Building the provider
 
@@ -78,19 +78,25 @@ $ make localinstall
 
 ## Using the provider
 
-The definition of the provider is optional.  
-All the parameters could be setup by environment variables.  
+The definition of the provider is optional.
+All the parameters could be setup by environment variables.
 
 ```hcl
 provider netbox {
   # Environment variable NETBOX_URL
   url = "127.0.0.1:8000"
-  
+
   # Environment variable NETBOX_TOKEN
   token = "c07a2db4adb8b1e7f75e7c4369964e92f7680512"
-  
+
   # Environment variable NETBOX_SCHEME
   scheme = "http"
+
+  # Environment variable NETBOX_INSECURE
+  insecure = "true"
+
+  # Environment variable NETBOX_PRIVATE_KEY_FILE
+  private_key_file = "/path/to/private/key"
 }
 ```
 
@@ -103,8 +109,8 @@ commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/) rules.
 
 ## Examples
 
-You can find some examples in the examples folder.  
-Each example can be executed directly with command terraform init & terraform apply.  
+You can find some examples in the examples folder.
+Each example can be executed directly with command terraform init & terraform apply.
 You can set different environment variables for your test:
 * NETBOX_URL to define the URL and the port (127.0.0.1:8000 by default)
 * NETBOX_TOKEN to define the TOKEN to access the application (empty by default)

--- a/docs/data-sources/json_dcim_devices_list.md
+++ b/docs/data-sources/json_dcim_devices_list.md
@@ -5,7 +5,13 @@ Get json output from the dcim_devices_list Netbox endpoint
 ## Example Usage
 
 ```hcl
-data "netbox_json_dcim_devices_list" "test" {}
+data "netbox_json_dcim_devices_list" "test" {
+  filter {
+    name = ""
+    value = ""
+  }
+  limit = 0
+}
 output "example" {
   value = jsondecode(data.netbox_json_dcim_devices_list.test.json)
 }
@@ -13,7 +19,15 @@ output "example" {
 
 ## Argument Reference
 
-This function takes no arguments.
+The following arguments are supported:
+
+* ``filter`` (Optional). This block set should include "name" (String) and "value" (String).
+  Supported options:
+  - ``name`` The name of the device.
+  - ``name_ic`` The string containing some part of the device name.
+  - ``tag`` The tag of a device.
+  - ``cluster_id`` The ID of a cluster.
+* ``limit`` (Optional). The max number of returned results. If 0 is specified, all devices will be returned.
 
 ## Attributes Reference
 

--- a/docs/data-sources/json_dcim_interfaces_list.md
+++ b/docs/data-sources/json_dcim_interfaces_list.md
@@ -5,7 +5,10 @@ Get json output from the dcim_interfaces_list Netbox endpoint
 ## Example Usage
 
 ```hcl
-data "netbox_json_dcim_interfaces_list" "test" {}
+data "netbox_json_dcim_interfaces_list" "test" {
+  devicename = ""
+  limit = 0
+}
 output "example" {
   value = jsondecode(data.netbox_json_dcim_interfaces_list.test.json)
 }
@@ -13,7 +16,10 @@ output "example" {
 
 ## Argument Reference
 
-This function takes no arguments.
+The following arguments are supported:
+
+* ``devicename`` (Optional). The name of the interface device.
+* ``limit`` (Optional). The max number of returned results. If 0 is specified, all interfaces will be returned.
 
 ## Attributes Reference
 

--- a/docs/data-sources/json_secrets_secrets_list.md
+++ b/docs/data-sources/json_secrets_secrets_list.md
@@ -5,7 +5,13 @@ Get json output from the secrets_secrets_list Netbox endpoint
 ## Example Usage
 
 ```hcl
-data "netbox_json_secrets_secrets_list" "test" {}
+data "netbox_json_secrets_secrets_list" "test" {
+  filter {
+    name = ""
+    value = ""
+  }
+  limit = 0
+}
 output "example" {
   value = jsondecode(data.netbox_json_secrets_secrets_list.test.json)
 }
@@ -13,7 +19,13 @@ output "example" {
 
 ## Argument Reference
 
-This function takes no arguments.
+The following arguments are supported:
+
+* ``filter`` (Optional). This block set should include "name" (String) and "value" (String).
+  Supported options:
+  - ``device_name`` The name of the device.
+  - ``tag`` The tag of a secret.
+* ``limit`` (Optional). The max number of returned results. If 0 is specified, all secrets will be returned.
 
 ## Attributes Reference
 

--- a/docs/data-sources/json_virtualization_clusters_list.md
+++ b/docs/data-sources/json_virtualization_clusters_list.md
@@ -5,7 +5,13 @@ Get json output from the virtualization_clusters_list Netbox endpoint
 ## Example Usage
 
 ```hcl
-data "netbox_json_virtualization_clusters_list" "test" {}
+data "netbox_json_virtualization_clusters_list" "test" {
+  filter {
+    name = ""
+    value = ""
+  }
+  limit = 0
+}
 output "example" {
   value = jsondecode(data.netbox_json_virtualization_clusters_list.test.json)
 }
@@ -13,7 +19,14 @@ output "example" {
 
 ## Argument Reference
 
-This function takes no arguments.
+The following arguments are supported:
+
+* ``filter`` (Optional). This block set should include "name" (String) and "value" (String).
+  Supported options:
+  - ``name`` The name of the cluster.
+  - ``name_ic`` The string containing some part of the cluster name.
+  - ``tag`` The tag of a cluster.
+* ``limit`` (Optional). The max number of returned results. If 0 is specified, all clusters will be returned.
 
 ## Attributes Reference
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,8 @@ Terraform provider for [Netbox.](https://netbox.readthedocs.io/en/stable/)
 
 ## Compatibility with Netbox
 
-Version 0.x.y => Netbox 2.8  
-Version 1.x.y => Netbox 2.9  
+Version 0.x.y => Netbox 2.8
+Version 1.x.y => Netbox 2.9
 
 ## Example Usage
 
@@ -22,6 +22,9 @@ provider netbox {
 
   # Environment variable NETBOX_SCHEME
   scheme = "http"
+
+  # Environment variable NETBOX_PRIVATE_KEY_FILE
+  private_key_file = "/path/to/private/key"
 }
 ```
 
@@ -32,3 +35,4 @@ provider netbox {
 * `token` or `NETBOX_TOKEN` environment variable to define the TOKEN to access the application (empty by default)
 * `scheme` or `NETBOX_SCHEME` environment variable to define the SCHEME of the URL (https by default)
 * `insecure` or `NETBOX_INSECURE` environment variable to skip or not the TLS certificat validation (false by default)
+* `private_key_file` or `NETBOX_PRIVATE_KEY_FILE` environment variable to add a private key to work with encoded data like secrets (empty by default)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,9 @@ provider netbox {
   # Environment variable NETBOX_SCHEME
   scheme = "http"
 
+  # Environment variable NETBOX_INSECURE
+  insecure = "true"
+
   # Environment variable NETBOX_PRIVATE_KEY_FILE
   private_key_file = "/path/to/private/key"
 }

--- a/netbox/data_netbox_json_dcim_devices_list.go
+++ b/netbox/data_netbox_json_dcim_devices_list.go
@@ -1,37 +1,85 @@
 package netbox
 
 import (
-        "encoding/json"
+	"encoding/json"
+	"fmt"
 
-        "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-        netboxclient "github.com/netbox-community/go-netbox/netbox/client"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	netboxclient "github.com/netbox-community/go-netbox/netbox/client"
+	"github.com/netbox-community/go-netbox/netbox/client/dcim"
 )
 
 func dataNetboxJSONDcimDevicesList() *schema.Resource {
-        return &schema.Resource{
-                Read: dataNetboxJSONDcimDevicesListRead,
+	return &schema.Resource{
+		Read: dataNetboxJSONDcimDevicesListRead,
 
-                Schema: map[string]*schema.Schema{
-                        "json": {
-                                Type:     schema.TypeString,
-                                Computed: true,
-                        },
-                },
-        }
+		Schema: map[string]*schema.Schema{
+			"filter": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"limit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+			"json": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
 }
 
 func dataNetboxJSONDcimDevicesListRead(d *schema.ResourceData, m interface{}) error {
-        client := m.(*netboxclient.NetBoxAPI)
+	client := m.(*netboxclient.NetBoxAPI)
 
-        list, err := client.Dcim.DcimDevicesList(nil, nil)
-        if err != nil {
-                return err
-        }
+	params := dcim.NewDcimDevicesListParams()
+	limit := int64(d.Get("limit").(int))
+	if filter, ok := d.GetOk("filter"); ok {
+		var filterParams = filter.(*schema.Set)
+		for _, f := range filterParams.List() {
+			k := f.(map[string]interface{})["name"]
+			v := f.(map[string]interface{})["value"]
+			vString := v.(string)
+			switch k {
+			case "name":
+				params.Name = &vString
+			case "name_ic":
+				params.NameIc = &vString
+			case "tag":
+				params.Tag = &vString
+			case "cluster_id":
+				params.ClusterID = &vString
+			default:
+				return fmt.Errorf("'%s' is not a supported filter parameter", k)
+			}
+		}
+	} else {
+		params.Limit = &limit
+	}
 
-        j, _ := json.Marshal(list.Payload.Results)
+	list, err := client.Dcim.DcimDevicesList(params, nil)
+	if err != nil {
+		return err
+	}
 
-        d.Set("json", string(j))
-        d.SetId("NetboxJSONDcimDevicesList")
+	j, _ := json.Marshal(list.Payload.Results)
 
-        return nil
+	d.Set("json", string(j))
+	d.SetId("NetboxJSONDcimDevicesList")
+
+	return nil
 }

--- a/netbox/data_netbox_json_dcim_devices_list.go
+++ b/netbox/data_netbox_json_dcim_devices_list.go
@@ -67,9 +67,9 @@ func dataNetboxJSONDcimDevicesListRead(d *schema.ResourceData, m interface{}) er
 				return fmt.Errorf("'%s' is not a supported filter parameter", k)
 			}
 		}
-	} else {
-		params.Limit = &limit
 	}
+
+	params.Limit = &limit
 
 	list, err := client.Dcim.DcimDevicesList(params, nil)
 	if err != nil {

--- a/netbox/data_netbox_json_dcim_interfaces_list.go
+++ b/netbox/data_netbox_json_dcim_interfaces_list.go
@@ -1,37 +1,55 @@
 package netbox
 
 import (
-        "encoding/json"
+	"encoding/json"
 
-        "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-        netboxclient "github.com/netbox-community/go-netbox/netbox/client"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	netboxclient "github.com/netbox-community/go-netbox/netbox/client"
+	"github.com/netbox-community/go-netbox/netbox/client/dcim"
 )
 
 func dataNetboxJSONDcimInterfacesList() *schema.Resource {
-        return &schema.Resource{
-                Read: dataNetboxJSONDcimInterfacesListRead,
+	return &schema.Resource{
+		Read: dataNetboxJSONDcimInterfacesListRead,
 
-                Schema: map[string]*schema.Schema{
-                        "json": {
-                                Type:     schema.TypeString,
-                                Computed: true,
-                        },
-                },
-        }
+		Schema: map[string]*schema.Schema{
+			"devicename": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"limit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+			"json": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
 }
 
 func dataNetboxJSONDcimInterfacesListRead(d *schema.ResourceData, m interface{}) error {
-        client := m.(*netboxclient.NetBoxAPI)
+	client := m.(*netboxclient.NetBoxAPI)
 
-        list, err := client.Dcim.DcimInterfacesList(nil, nil)
-        if err != nil {
-                return err
-        }
+	deviceName := d.Get("devicename").(string)
+	limit := int64(d.Get("limit").(int))
+	params := dcim.NewDcimInterfacesListParams()
+	if deviceName != "" {
+		params.Device = &deviceName
+	}
+	params.Limit = &limit
 
-        j, _ := json.Marshal(list.Payload.Results)
+	list, err := client.Dcim.DcimInterfacesList(params, nil)
+	if err != nil {
+		return err
+	}
 
-        d.Set("json", string(j))
-        d.SetId("NetboxJSONDcimInterfacesList")
+	j, _ := json.Marshal(list.Payload.Results)
 
-        return nil
+	d.Set("json", string(j))
+	d.SetId("NetboxJSONDcimInterfacesList")
+
+	return nil
 }

--- a/netbox/data_netbox_json_secrets_secrets_list.go
+++ b/netbox/data_netbox_json_secrets_secrets_list.go
@@ -64,9 +64,9 @@ func dataNetboxJSONSecretsSecretsListRead(d *schema.ResourceData, m interface{})
 				return fmt.Errorf("'%s' is not a supported filter parameter", k)
 			}
 		}
-	} else {
-		params.Limit = &limit
 	}
+
+	params.Limit = &limit
 
 	list, err := client.Secrets.SecretsSecretsList(params, nil)
 	if err != nil {

--- a/netbox/data_netbox_json_secrets_secrets_list.go
+++ b/netbox/data_netbox_json_secrets_secrets_list.go
@@ -1,37 +1,82 @@
 package netbox
 
 import (
-        "encoding/json"
+	"encoding/json"
+	"fmt"
 
-        "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-        netboxclient "github.com/netbox-community/go-netbox/netbox/client"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	netboxclient "github.com/netbox-community/go-netbox/netbox/client"
+	"github.com/netbox-community/go-netbox/netbox/client/secrets"
 )
 
 func dataNetboxJSONSecretsSecretsList() *schema.Resource {
-        return &schema.Resource{
-                Read: dataNetboxJSONSecretsSecretsListRead,
+	return &schema.Resource{
+		Read: dataNetboxJSONSecretsSecretsListRead,
 
-                Schema: map[string]*schema.Schema{
-                        "json": {
-                                Type:     schema.TypeString,
-                                Computed: true,
-                        },
-                },
-        }
+		Schema: map[string]*schema.Schema{
+			"filter": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"limit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+			"json": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
 }
 
 func dataNetboxJSONSecretsSecretsListRead(d *schema.ResourceData, m interface{}) error {
-        client := m.(*netboxclient.NetBoxAPI)
+	client := m.(*netboxclient.NetBoxAPI)
 
-        list, err := client.Secrets.SecretsSecretsList(nil, nil)
-        if err != nil {
-                return err
-        }
+	params := secrets.NewSecretsSecretsListParams()
 
-        j, _ := json.Marshal(list.Payload.Results)
+	limit := int64(d.Get("limit").(int))
+	if filter, ok := d.GetOk("filter"); ok {
+		var filterParams = filter.(*schema.Set)
+		for _, f := range filterParams.List() {
+			k := f.(map[string]interface{})["name"]
+			v := f.(map[string]interface{})["value"]
+			vString := v.(string)
+			switch k {
+			case "device_name":
+				params.Device = &vString
+			case "tag":
+				params.Tag = &vString
+			default:
+				return fmt.Errorf("'%s' is not a supported filter parameter", k)
+			}
+		}
+	} else {
+		params.Limit = &limit
+	}
 
-        d.Set("json", string(j))
-        d.SetId("NetboxJSONSecretsSecretsList")
+	list, err := client.Secrets.SecretsSecretsList(params, nil)
+	if err != nil {
+		return err
+	}
 
-        return nil
+	j, _ := json.Marshal(list.Payload.Results)
+
+	d.Set("json", string(j))
+	d.SetId("NetboxJSONSecretsSecretsList")
+
+	return nil
 }

--- a/netbox/data_netbox_json_virtualization_clusters_list.go
+++ b/netbox/data_netbox_json_virtualization_clusters_list.go
@@ -1,37 +1,83 @@
 package netbox
 
 import (
-        "encoding/json"
+	"encoding/json"
+	"fmt"
 
-        "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-        netboxclient "github.com/netbox-community/go-netbox/netbox/client"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	netboxclient "github.com/netbox-community/go-netbox/netbox/client"
+	"github.com/netbox-community/go-netbox/netbox/client/virtualization"
 )
 
 func dataNetboxJSONVirtualizationClustersList() *schema.Resource {
-        return &schema.Resource{
-                Read: dataNetboxJSONVirtualizationClustersListRead,
+	return &schema.Resource{
+		Read: dataNetboxJSONVirtualizationClustersListRead,
 
-                Schema: map[string]*schema.Schema{
-                        "json": {
-                                Type:     schema.TypeString,
-                                Computed: true,
-                        },
-                },
-        }
+		Schema: map[string]*schema.Schema{
+			"filter": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"limit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+			"json": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
 }
 
 func dataNetboxJSONVirtualizationClustersListRead(d *schema.ResourceData, m interface{}) error {
-        client := m.(*netboxclient.NetBoxAPI)
+	client := m.(*netboxclient.NetBoxAPI)
 
-        list, err := client.Virtualization.VirtualizationClustersList(nil, nil)
-        if err != nil {
-                return err
-        }
+	params := virtualization.NewVirtualizationClustersListParams()
+	limit := int64(d.Get("limit").(int))
+	if filter, ok := d.GetOk("filter"); ok {
+		var filterParams = filter.(*schema.Set)
+		for _, f := range filterParams.List() {
+			k := f.(map[string]interface{})["name"]
+			v := f.(map[string]interface{})["value"]
+			vString := v.(string)
+			switch k {
+			case "name":
+				params.Name = &vString
+			case "name_ic":
+				params.NameIc = &vString
+			case "tag":
+				params.Tag = &vString
+			default:
+				return fmt.Errorf("'%s' is not a supported filter parameter", k)
+			}
+		}
+	} else {
+		params.Limit = &limit
+	}
 
-        j, _ := json.Marshal(list.Payload.Results)
+	list, err := client.Virtualization.VirtualizationClustersList(params, nil)
+	if err != nil {
+		return err
+	}
 
-        d.Set("json", string(j))
-        d.SetId("NetboxJSONVirtualizationClustersList")
+	j, _ := json.Marshal(list.Payload.Results)
 
-        return nil
+	d.Set("json", string(j))
+	d.SetId("NetboxJSONVirtualizationClustersList")
+
+	return nil
 }

--- a/netbox/data_netbox_json_virtualization_clusters_list.go
+++ b/netbox/data_netbox_json_virtualization_clusters_list.go
@@ -65,9 +65,9 @@ func dataNetboxJSONVirtualizationClustersListRead(d *schema.ResourceData, m inte
 				return fmt.Errorf("'%s' is not a supported filter parameter", k)
 			}
 		}
-	} else {
-		params.Limit = &limit
 	}
+
+	params.Limit = &limit
 
 	list, err := client.Virtualization.VirtualizationClustersList(params, nil)
 	if err != nil {

--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -166,7 +166,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 	headers := make(map[string]string)
 
 	if privateKeyFile != "" {
-		privateKey, _ := ReadRSAKey(privateKeyFile)
+		privateKey := ReadRSAKey(privateKeyFile)
 		sessionKey := GetSessionKey(fmt.Sprintf("%s://%s", scheme, url), token, privateKey)
 		headers["X-Session-Key"] = sessionKey
 	}

--- a/netbox/util.go
+++ b/netbox/util.go
@@ -1,7 +1,13 @@
 package netbox
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
 	netboxclient "github.com/netbox-community/go-netbox/netbox/client"
 	"github.com/netbox-community/go-netbox/netbox/client/virtualization"
 	"github.com/netbox-community/go-netbox/netbox/models"
@@ -209,4 +215,31 @@ func convertCustomFieldsFromTerraformToAPIUpdate(stateCustomFields, resourceCust
 	}
 
 	return toReturn
+}
+
+func GetSessionKey(destinationUrl string, token string, rsaKey string) string {
+	privateKey := rsaKey
+	data := url.Values{}
+	data.Set("private_key", privateKey) // set private key string
+	destinationUrl = destinationUrl + "/api/secrets/get-session-key/"
+	// get session key
+	req, err := http.NewRequest("POST", destinationUrl, strings.NewReader(data.Encode())) // URL-enconded payload
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	req.Header.Set("Authorization", "Token "+token)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json; indent=4")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	content, err := ioutil.ReadAll(resp.Body)
+	m := make(map[string]string)
+	err = json.Unmarshal(content, &m) // convert json to dict
+
+	return m["session_key"]
 }

--- a/netbox/util.go
+++ b/netbox/util.go
@@ -217,6 +217,14 @@ func convertCustomFieldsFromTerraformToAPIUpdate(stateCustomFields, resourceCust
 	return toReturn
 }
 
+func ReadRSAKey(filePath string) (res string, err error) {
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
 func GetSessionKey(destinationUrl string, token string, rsaKey string) string {
 	privateKey := rsaKey
 	data := url.Values{}

--- a/netbox/util.go
+++ b/netbox/util.go
@@ -217,12 +217,12 @@ func convertCustomFieldsFromTerraformToAPIUpdate(stateCustomFields, resourceCust
 	return toReturn
 }
 
-func ReadRSAKey(filePath string) (res string, err error) {
+func ReadRSAKey(filePath string) (res string) {
 	data, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		return "", err
+		return ""
 	}
-	return string(data), nil
+	return string(data)
 }
 
 func GetSessionKey(destinationUrl string, token string, rsaKey string) string {
@@ -230,10 +230,11 @@ func GetSessionKey(destinationUrl string, token string, rsaKey string) string {
 	data := url.Values{}
 	data.Set("private_key", privateKey) // set private key string
 	destinationUrl = destinationUrl + "/api/secrets/get-session-key/"
-	// get session key
+
 	req, err := http.NewRequest("POST", destinationUrl, strings.NewReader(data.Encode())) // URL-enconded payload
 	if err != nil {
-		fmt.Println(err)
+		//
+		return ""
 	}
 
 	req.Header.Set("Authorization", "Token "+token)
@@ -242,12 +243,12 @@ func GetSessionKey(destinationUrl string, token string, rsaKey string) string {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		fmt.Println(err)
+		return ""
 	}
 
 	content, err := ioutil.ReadAll(resp.Body)
 	m := make(map[string]string)
-	err = json.Unmarshal(content, &m) // convert json to dict
+	err = json.Unmarshal(content, &m) // convert json to map
 
 	return m["session_key"]
 }


### PR DESCRIPTION
- Add the filter block to the following data resources: secrets_list, clusters_list, devices_list
- Add the devicename argument to interfaces_list
- Add the limit param to secrets_list, clusters_list, devices_list, interfaces_list
- Add an option to initialize the client with the private key to read encoded data like secrets
- Document the changes
The changes have been tested with NetBox version 2.10.4.
----
I will be glad to make any changes if needed.