### PR TITLE
Custom field and default field value fixes

### DIFF
--- a/netbox/util.go
+++ b/netbox/util.go
@@ -246,9 +246,9 @@ func convertCustomFieldsFromTerraformToAPI(stateCustomFields []interface{}, cust
 			toReturn[cfName] = cfValueInt
 		} else if cfType == CustomFieldBoolean {
 			if cfValue == "true" {
-				toReturn[cfName] = 1
+				toReturn[cfName] = true
 			} else if cfValue == "false" {
-				toReturn[cfName] = 0
+				toReturn[cfName] = false
 			}
 		} else if cfType == "multiple" {
 			cfValueArray := strings.Split(cfValue, ",")


### PR DESCRIPTION
### Custom field and default field value fixes

In general, match the default UI behaviour.

1. **Handle Boolean values type correctly**
 Netbox will accept the previous Integer values but they will be stored as Integers and not casted to Boolean. This breaks the web UI (which will show undefined) and anything that queries the API expecting a Boolean type as an Integer will be returned.
2. **Handle empty custom fields correctly**
    Empty custom fields should be passed as nil to Netbox and nil values from Netbox should be passed to Terraform as an empty string. Netbox distingushes between an Empty string and null so this behaviour mirrors the web UI.

### Issue

- #83

