### PR TITLE
fix: Store empty static String field as nil in TF state

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
         go: [ '1.16.x' ]
     steps:
       - name: Check conventional commits in PR
-        uses: Namchee/conventional-pr@v0.6.0
+        uses: Namchee/conventional-pr@v0.7.0
         with:
           access_token: ${{ secrets.github_token }}
           label: "no-conventional-commits"

--- a/netbox/resource_netbox_ipam_aggregate.go
+++ b/netbox/resource_netbox_ipam_aggregate.go
@@ -63,7 +63,7 @@ func resourceNetboxIpamAggregate() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      " ",
+				Default:      nil,
 				ValidateFunc: validation.StringLenBetween(1, 200),
 			},
 			"prefix": {
@@ -171,9 +171,9 @@ func resourceNetboxIpamAggregateRead(d *schema.ResourceData,
 				return err
 			}
 
-			var description string
+			var description interface{}
 			if resource.Description == "" {
-				description = " "
+				description = nil
 			} else {
 				description = resource.Description
 			}
@@ -241,8 +241,11 @@ func resourceNetboxIpamAggregateUpdate(d *schema.ResourceData,
 	}
 
 	if d.HasChange("description") {
-		description := d.Get("description").(string)
-		params.Description = description
+		if description, exist := d.GetOk("description"); exist {
+			params.Description = description.(string)
+		} else {
+			params.Description = " "
+		}
 	}
 
 	tags := d.Get("tag").(*schema.Set).List()

--- a/netbox/resource_netbox_ipam_ip_addresses.go
+++ b/netbox/resource_netbox_ipam_ip_addresses.go
@@ -54,13 +54,13 @@ func resourceNetboxIpamIPAddresses() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      " ",
+				Default:      nil,
 				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
 			"dns_name": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  " ",
+				Default:  nil,
 				ValidateFunc: validation.StringMatch(
 					regexp.MustCompile("^[-a-zA-Z0-9_.]{1,255}$"),
 					"Must be like ^[-a-zA-Z0-9_.]{1,255}$"),
@@ -228,9 +228,9 @@ func resourceNetboxIpamIPAddressesRead(d *schema.ResourceData,
 				return err
 			}
 
-			var description string
+			var description interface{}
 			if resource.Description == "" {
-				description = " "
+				description = nil
 			} else {
 				description = resource.Description
 			}
@@ -239,9 +239,9 @@ func resourceNetboxIpamIPAddressesRead(d *schema.ResourceData,
 				return err
 			}
 
-			var dnsName string
+			var dnsName interface{}
 			if resource.DNSName == "" {
-				dnsName = " "
+				dnsName = nil
 			} else {
 				dnsName = resource.DNSName
 			}
@@ -386,7 +386,11 @@ func resourceNetboxIpamIPAddressesUpdate(d *schema.ResourceData,
 	}
 
 	if d.HasChange("dns_name") {
-		params.DNSName = d.Get("dns_name").(string)
+		if dnsName, exist := d.GetOk("dns_name"); exist {
+			params.DNSName = dnsName.(string)
+		} else {
+			params.DNSName = " "
+		}
 	}
 
 	if d.HasChange("nat_inside_id") {

--- a/netbox/resource_netbox_ipam_prefix.go
+++ b/netbox/resource_netbox_ipam_prefix.go
@@ -48,7 +48,7 @@ func resourceNetboxIpamPrefix() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      " ",
+				Default:      nil,
 				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
 			"is_pool": {
@@ -186,10 +186,9 @@ func resourceNetboxIpamPrefixRead(d *schema.ResourceData,
 				return err
 			}
 
-			var description string
-
+			var description interface{}
 			if resource.Description == "" {
-				description = " "
+				description = nil
 			} else {
 				description = resource.Description
 			}
@@ -294,8 +293,11 @@ func resourceNetboxIpamPrefixUpdate(d *schema.ResourceData,
 	}
 
 	if d.HasChange("description") {
-		description := d.Get("description").(string)
-		params.Description = description
+		if description, exist := d.GetOk("description"); exist {
+			params.Description = description.(string)
+		} else {
+			params.Description = " "
+		}
 	}
 
 	params.IsPool = d.Get("is_pool").(bool)

--- a/netbox/resource_netbox_ipam_service.go
+++ b/netbox/resource_netbox_ipam_service.go
@@ -48,7 +48,7 @@ func resourceNetboxIpamService() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      " ",
+				Default:      nil,
 				ValidateFunc: validation.StringLenBetween(1, 200),
 			},
 			"device_id": {
@@ -178,10 +178,9 @@ func resourceNetboxIpamServiceRead(d *schema.ResourceData,
 				return err
 			}
 
-			var description string
-
+			var description interface{}
 			if resource.Description == "" {
-				description = " "
+				description = nil
 			} else {
 				description = resource.Description
 			}
@@ -289,8 +288,11 @@ func resourceNetboxIpamServiceUpdate(d *schema.ResourceData,
 	}
 
 	if d.HasChange("description") {
-		description := d.Get("description").(string)
-		params.Description = description
+		if description, exist := d.GetOk("description"); exist {
+			params.Description = description.(string)
+		} else {
+			params.Description = " "
+		}
 	}
 
 	tags := d.Get("tag").(*schema.Set).List()

--- a/netbox/resource_netbox_ipam_vlan.go
+++ b/netbox/resource_netbox_ipam_vlan.go
@@ -48,7 +48,7 @@ func resourceNetboxIpamVlan() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      " ",
+				Default:      nil,
 				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
 			"vlan_group_id": {
@@ -175,10 +175,9 @@ func resourceNetboxIpamVlanRead(d *schema.ResourceData,
 				return err
 			}
 
-			var description string
-
+			var description interface{}
 			if resource.Description == "" {
-				description = " "
+				description = nil
 			} else {
 				description = resource.Description
 			}
@@ -270,8 +269,11 @@ func resourceNetboxIpamVlanUpdate(d *schema.ResourceData,
 	params.Vid = &vid
 
 	if d.HasChange("description") {
-		description := d.Get("description").(string)
-		params.Description = description
+		if description, exist := d.GetOk("description"); exist {
+			params.Description = description.(string)
+		} else {
+			params.Description = " "
+		}
 	}
 
 	if d.HasChange("custom_field") {

--- a/netbox/resource_netbox_tenancy_tenant.go
+++ b/netbox/resource_netbox_tenancy_tenant.go
@@ -27,7 +27,7 @@ func resourceNetboxTenancyTenant() *schema.Resource {
 			"comments": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  " ",
+				Default:  nil,
 			},
 			"custom_field": {
 				Type:     schema.TypeSet,
@@ -54,7 +54,7 @@ func resourceNetboxTenancyTenant() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      " ",
+				Default:      nil,
 				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
 			"tenant_group_id": {
@@ -145,10 +145,10 @@ func resourceNetboxTenancyTenantRead(d *schema.ResourceData,
 
 	for _, resource := range resources.Payload.Results {
 		if strconv.FormatInt(resource.ID, 10) == d.Id() {
-			var comments string
 
+			var comments interface{}
 			if resource.Comments == "" {
-				comments = " "
+				comments = nil
 			} else {
 				comments = resource.Comments
 			}
@@ -164,10 +164,9 @@ func resourceNetboxTenancyTenantRead(d *schema.ResourceData,
 				return err
 			}
 
-			var description string
-
+			var description interface{}
 			if resource.Description == "" {
-				description = " "
+				description = nil
 			} else {
 				description = resource.Description
 			}
@@ -219,8 +218,11 @@ func resourceNetboxTenancyTenantUpdate(d *schema.ResourceData,
 	params.Slug = &slug
 
 	if d.HasChange("comments") {
-		comments := d.Get("comments").(string)
-		params.Comments = comments
+		if comments, exist := d.GetOk("comments"); exist {
+			params.Comments = comments.(string)
+		} else {
+			params.Comments = " "
+		}
 	}
 
 	if d.HasChange("custom_field") {
@@ -230,8 +232,11 @@ func resourceNetboxTenancyTenantUpdate(d *schema.ResourceData,
 	}
 
 	if d.HasChange("description") {
-		description := d.Get("description").(string)
-		params.Description = description
+		if description, exist := d.GetOk("description"); exist {
+			params.Description = description.(string)
+		} else {
+			params.Description = " "
+		}
 	}
 
 	if d.HasChange("tenant_group_id") {

--- a/netbox/resource_netbox_virtualization_interface.go
+++ b/netbox/resource_netbox_virtualization_interface.go
@@ -49,7 +49,7 @@ func resourceNetboxVirtualizationInterface() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      " ",
+				Default:      nil,
 				ValidateFunc: validation.StringLenBetween(1, 200),
 			},
 			"enabled": {
@@ -199,10 +199,9 @@ func resourceNetboxVirtualizationInterfaceRead(d *schema.ResourceData,
 				return err
 			}
 
-			var description string
-
+			var description interface{}
 			if resource.Description == "" {
-				description = " "
+				description = nil
 			} else {
 				description = resource.Description
 			}
@@ -293,8 +292,11 @@ func resourceNetboxVirtualizationInterfaceUpdate(d *schema.ResourceData,
 	}
 
 	if d.HasChange("description") {
-		description := d.Get("description").(string)
-		params.Description = description
+		if description, exist := d.GetOk("description"); exist {
+			params.Description = description.(string)
+		} else {
+			params.Description = " "
+		}
 	}
 
 	if d.HasChange("enabled") {

--- a/netbox/resource_netbox_virtualization_vm.go
+++ b/netbox/resource_netbox_virtualization_vm.go
@@ -32,7 +32,7 @@ func resourceNetboxVirtualizationVM() *schema.Resource {
 			"comments": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  " ",
+				Default:  nil,
 			},
 			"custom_field": {
 				Type:     schema.TypeSet,
@@ -218,10 +218,9 @@ func resourceNetboxVirtualizationVMRead(d *schema.ResourceData,
 				return err
 			}
 
-			var comments string
-
+			var comments interface{}
 			if resource.Comments == "" {
-				comments = " "
+				comments = nil
 			} else {
 				comments = resource.Comments
 			}
@@ -316,8 +315,11 @@ func resourceNetboxVirtualizationVMUpdate(d *schema.ResourceData,
 	params.Cluster = &clusterID
 
 	if d.HasChange("comments") {
-		comments := d.Get("comments").(string)
-		params.Comments = comments
+		if comments, exist := d.GetOk("comments"); exist {
+			params.Comments = comments.(string)
+		} else {
+			params.Comments = " "
+		}
 	}
 
 	if d.HasChange("custom_field") {


### PR DESCRIPTION
The 'static' String fields (description/dns_name) when empty are
returned via the Netbox API as an empty String `""` but they cannot
be cleared by POST/PATCH-ing an emptry String or null value. They are
cleared by setting a single whitespace character `" "`, before this
change these empty fields were always stored in the TF state as an existent
resource property even though they were unset. This also resulted in
these whitespace values being sent to Netbox every time a resource was
created/updated.

This change stores unset fields as `nil` and sets the default values of
the description and dns_name property to `nil`. Empty String fields are
stored as nil when reading from Netbox and nil fields are POST/PATCH-ed
to Netbox as the single whitespace String `" "`. When unset the
properties will not be sent in the request body to Netbox and will not
show in the TF show command.