### PR TITLE
fix: Allow setting local_context_data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
-	github.com/smutel/go-netbox v3.0.0+incompatible
+	github.com/smutel/go-netbox v3.0.1+incompatible
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -485,6 +485,8 @@ github.com/smutel/go-netbox v2.11.0+incompatible h1:ADb7xHCQd6nOyNRZDD1CzYOqKarG
 github.com/smutel/go-netbox v2.11.0+incompatible/go.mod h1:UlNOimilX5qQkyVvFaDgajexiCRjVqzh1i0r9kQfr+M=
 github.com/smutel/go-netbox v3.0.0+incompatible h1:Jx8yGdB+BYBqi46bn/VNY5qBGzAtmQ9Z2E66YMmwyRI=
 github.com/smutel/go-netbox v3.0.0+incompatible/go.mod h1:UlNOimilX5qQkyVvFaDgajexiCRjVqzh1i0r9kQfr+M=
+github.com/smutel/go-netbox v3.0.1+incompatible h1:g/A7Hce+PPwYjbHLJrNHx7jhobB6n/VPJNkP/NiykOU=
+github.com/smutel/go-netbox v3.0.1+incompatible/go.mod h1:UlNOimilX5qQkyVvFaDgajexiCRjVqzh1i0r9kQfr+M=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=

--- a/netbox/resource_netbox_virtualization_vm.go
+++ b/netbox/resource_netbox_virtualization_vm.go
@@ -249,13 +249,17 @@ func resourceNetboxVirtualizationVMRead(d *schema.ResourceData,
 				return err
 			}
 
-			localContextDataJSON, err := json.Marshal(resource.LocalContextData)
-			if err != nil {
-				return err
-			}
-			if err = d.Set("local_context_data",
-				string(localContextDataJSON)); err != nil {
-				return err
+			if resource.LocalContextData != nil {
+				localContextDataJSON, err := json.Marshal(resource.LocalContextData)
+				if err != nil {
+					return err
+				}
+				if err = d.Set("local_context_data",
+					string(localContextDataJSON)); err != nil {
+					return err
+				}
+			} else {
+				d.Set("local_context_data", "");
 			}
 
 			if err = d.Set("memory", resource.Memory); err != nil {
@@ -349,7 +353,9 @@ func resourceNetboxVirtualizationVMUpdate(d *schema.ResourceData,
 	if d.HasChange("local_context_data") {
 		localContextData := d.Get("local_context_data").(string)
 		var localContextDataMap map[string]*interface{}
-		if err := json.Unmarshal([]byte(localContextData), &localContextDataMap); err != nil {
+		if localContextData == "" {
+			localContextDataMap = nil
+		} else if err := json.Unmarshal([]byte(localContextData), &localContextDataMap); err != nil {
 						return err
 		}
 		params.LocalContextData = localContextDataMap

--- a/netbox/resource_netbox_virtualization_vm.go
+++ b/netbox/resource_netbox_virtualization_vm.go
@@ -1,6 +1,7 @@
 package netbox
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -156,7 +157,6 @@ func resourceNetboxVirtualizationVMCreate(d *schema.ResourceData,
 		Cluster:          &clusterID,
 		Comments:         comments,
 		CustomFields:     &customFields,
-		LocalContextData: &localContextData,
 		Name:             &name,
 		Status:           status,
 		Tags:             convertTagsToNestedTags(tags),
@@ -168,6 +168,14 @@ func resourceNetboxVirtualizationVMCreate(d *schema.ResourceData,
 
 	if memory != 0 {
 		newResource.Memory = &memory
+	}
+
+	if localContextData != "" {
+		var localContextDataMap map[string]*interface{}
+		if err := json.Unmarshal([]byte(localContextData), &localContextDataMap); err != nil {
+						return err
+		}
+		newResource.LocalContextData = localContextDataMap
 	}
 
 	if platformID != 0 {
@@ -241,8 +249,12 @@ func resourceNetboxVirtualizationVMRead(d *schema.ResourceData,
 				return err
 			}
 
+			localContextDataJSON, err := json.Marshal(resource.LocalContextData)
+			if err != nil {
+				return err
+			}
 			if err = d.Set("local_context_data",
-				*resource.LocalContextData); err != nil {
+				string(localContextDataJSON)); err != nil {
 				return err
 			}
 
@@ -336,7 +348,11 @@ func resourceNetboxVirtualizationVMUpdate(d *schema.ResourceData,
 
 	if d.HasChange("local_context_data") {
 		localContextData := d.Get("local_context_data").(string)
-		params.LocalContextData = &localContextData
+		var localContextDataMap map[string]*interface{}
+		if err := json.Unmarshal([]byte(localContextData), &localContextDataMap); err != nil {
+						return err
+		}
+		params.LocalContextData = localContextDataMap
 	}
 
 	if d.HasChange("memory") {

--- a/vendor/github.com/smutel/go-netbox/netbox/models/device.go
+++ b/vendor/github.com/smutel/go-netbox/netbox/models/device.go
@@ -81,7 +81,7 @@ type Device struct {
 	LastUpdated strfmt.DateTime `json:"last_updated,omitempty"`
 
 	// Local context data
-	LocalContextData *string `json:"local_context_data,omitempty"`
+	LocalContextData interface{} `json:"local_context_data,omitempty"`
 
 	// location
 	Location *NestedLocation `json:"location,omitempty"`

--- a/vendor/github.com/smutel/go-netbox/netbox/models/device_with_config_context.go
+++ b/vendor/github.com/smutel/go-netbox/netbox/models/device_with_config_context.go
@@ -50,7 +50,7 @@ type DeviceWithConfigContext struct {
 
 	// Config context
 	// Read Only: true
-	ConfigContext map[string]*string `json:"config_context,omitempty"`
+	ConfigContext interface{} `json:"config_context,omitempty"`
 
 	// Created
 	// Read Only: true
@@ -85,7 +85,7 @@ type DeviceWithConfigContext struct {
 	LastUpdated strfmt.DateTime `json:"last_updated,omitempty"`
 
 	// Local context data
-	LocalContextData *string `json:"local_context_data,omitempty"`
+	LocalContextData interface{} `json:"local_context_data,omitempty"`
 
 	// location
 	Location *NestedLocation `json:"location,omitempty"`
@@ -707,10 +707,6 @@ func (m *DeviceWithConfigContext) ContextValidate(ctx context.Context, formats s
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateConfigContext(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateCreated(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -809,11 +805,6 @@ func (m *DeviceWithConfigContext) contextValidateCluster(ctx context.Context, fo
 			return err
 		}
 	}
-
-	return nil
-}
-
-func (m *DeviceWithConfigContext) contextValidateConfigContext(ctx context.Context, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/vendor/github.com/smutel/go-netbox/netbox/models/virtual_machine_with_config_context.go
+++ b/vendor/github.com/smutel/go-netbox/netbox/models/virtual_machine_with_config_context.go
@@ -45,7 +45,7 @@ type VirtualMachineWithConfigContext struct {
 
 	// Config context
 	// Read Only: true
-	ConfigContext map[string]*string `json:"config_context,omitempty"`
+	ConfigContext interface{} `json:"config_context,omitempty"`
 
 	// Created
 	// Read Only: true
@@ -74,7 +74,7 @@ type VirtualMachineWithConfigContext struct {
 	LastUpdated strfmt.DateTime `json:"last_updated,omitempty"`
 
 	// Local context data
-	LocalContextData *string `json:"local_context_data,omitempty"`
+	LocalContextData interface{} `json:"local_context_data,omitempty"`
 
 	// Memory (MB)
 	// Maximum: 2.147483647e+09
@@ -505,10 +505,6 @@ func (m *VirtualMachineWithConfigContext) ContextValidate(ctx context.Context, f
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateConfigContext(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateCreated(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -583,11 +579,6 @@ func (m *VirtualMachineWithConfigContext) contextValidateCluster(ctx context.Con
 			return err
 		}
 	}
-
-	return nil
-}
-
-func (m *VirtualMachineWithConfigContext) contextValidateConfigContext(ctx context.Context, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/vendor/github.com/smutel/go-netbox/netbox/models/writable_device_with_config_context.go
+++ b/vendor/github.com/smutel/go-netbox/netbox/models/writable_device_with_config_context.go
@@ -50,7 +50,7 @@ type WritableDeviceWithConfigContext struct {
 
 	// Config context
 	// Read Only: true
-	ConfigContext map[string]*string `json:"config_context,omitempty"`
+	ConfigContext interface{} `json:"config_context,omitempty"`
 
 	// Created
 	// Read Only: true
@@ -86,7 +86,7 @@ type WritableDeviceWithConfigContext struct {
 	LastUpdated strfmt.DateTime `json:"last_updated,omitempty"`
 
 	// Local context data
-	LocalContextData *string `json:"local_context_data,omitempty"`
+	LocalContextData interface{} `json:"local_context_data,omitempty"`
 
 	// Location
 	Location *int64 `json:"location,omitempty"`
@@ -527,10 +527,6 @@ func (m *WritableDeviceWithConfigContext) validateVcPriority(formats strfmt.Regi
 func (m *WritableDeviceWithConfigContext) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.contextValidateConfigContext(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateCreated(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -566,11 +562,6 @@ func (m *WritableDeviceWithConfigContext) ContextValidate(ctx context.Context, f
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
-	return nil
-}
-
-func (m *WritableDeviceWithConfigContext) contextValidateConfigContext(ctx context.Context, formats strfmt.Registry) error {
-
 	return nil
 }
 

--- a/vendor/github.com/smutel/go-netbox/netbox/models/writable_virtual_machine_with_config_context.go
+++ b/vendor/github.com/smutel/go-netbox/netbox/models/writable_virtual_machine_with_config_context.go
@@ -45,7 +45,7 @@ type WritableVirtualMachineWithConfigContext struct {
 
 	// Config context
 	// Read Only: true
-	ConfigContext map[string]*string `json:"config_context,omitempty"`
+	ConfigContext interface{} `json:"config_context,omitempty"`
 
 	// Created
 	// Read Only: true
@@ -74,7 +74,7 @@ type WritableVirtualMachineWithConfigContext struct {
 	LastUpdated strfmt.DateTime `json:"last_updated,omitempty"`
 
 	// Local context data
-	LocalContextData *string `json:"local_context_data,omitempty"`
+	LocalContextData interface{} `json:"local_context_data,omitempty"`
 
 	// Memory (MB)
 	// Maximum: 2.147483647e+09
@@ -367,10 +367,6 @@ func (m *WritableVirtualMachineWithConfigContext) validateVcpus(formats strfmt.R
 func (m *WritableVirtualMachineWithConfigContext) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.contextValidateConfigContext(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateCreated(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -406,11 +402,6 @@ func (m *WritableVirtualMachineWithConfigContext) ContextValidate(ctx context.Co
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
-	return nil
-}
-
-func (m *WritableVirtualMachineWithConfigContext) contextValidateConfigContext(ctx context.Context, formats strfmt.Registry) error {
-
 	return nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -295,7 +295,7 @@ github.com/opentracing/opentracing-go/log
 github.com/posener/complete
 github.com/posener/complete/cmd
 github.com/posener/complete/cmd/install
-# github.com/smutel/go-netbox v3.0.0+incompatible
+# github.com/smutel/go-netbox v3.0.1+incompatible
 ## explicit
 github.com/smutel/go-netbox/netbox/client
 github.com/smutel/go-netbox/netbox/client/circuits


### PR DESCRIPTION
This PR fixes #59

local_context_data still needs to be a string in the resource due to limitations in terraform.
This fix needs https://github.com/smutel/go-netbox/pull/22 merged and updated in vendor/.

local_context_data can be specified as follows or as string
```
resource "netbox_virtualization_vm" "virtual_machines" {
  […]
      local_context_data = jsonencode(
            {
                    foo = "bar"
                    number = 1
            }
        )
}
```