### PR TITLE
feat: Add primary_ip6 field to ip_addresses

### DIFF
--- a/netbox/resource_netbox_ipam_ip_addresses.go
+++ b/netbox/resource_netbox_ipam_ip_addresses.go
@@ -203,14 +203,16 @@ func resourceNetboxIpamIPAddressesCreate(d *schema.ResourceData,
 
 	d.SetId(strconv.FormatInt(resourceCreated.Payload.ID, 10))
 
-	if primaryIP4 {
-		err = updatePrimaryStatus(client, info, resourceCreated.Payload.ID, true)
-	} else if primaryIP6 {
-		err = updatePrimaryStatus(client, info, resourceCreated.Payload.ID, false)
-	}
-	if err != nil {
-		return err
-	}
+  if primaryIP4 {
+    if err = updatePrimaryStatus(client, info, resourceCreated.Payload.ID, true); err != nil {
+		  return err
+		}
+  }
+  if primaryIP6 {
+    if err = updatePrimaryStatus(client, info, resourceCreated.Payload.ID, false); err != nil {
+      return err
+    }
+  }
 
 	return resourceNetboxIpamIPAddressesRead(d, m)
 }


### PR DESCRIPTION
This PR adds a primary_ip6 field to the netbox_ipam_ip_addresses resource.

The logic is mostly copied from the existing primary_ip4 field.

I'm not sure if this is the right way to go.

Another solution would be to deduce the address family from the address format and automatically set the right parameter. Then the primary_ip4 field could be renamed to primary_ip.