### PR TITLE
fix: Replace deprecated functions with context aware functions

### DIFF
--- a/netbox/data_netbox_dcim_platform.go
+++ b/netbox/data_netbox_dcim_platform.go
@@ -1,10 +1,11 @@
 package netbox
 
 import (
-	"fmt"
+	"context"
 	"regexp"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
@@ -14,7 +15,7 @@ import (
 func dataNetboxDcimPlatform() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get info about platform (dcim module) from netbox.",
-		Read:        dataNetboxDcimPlatformRead,
+		ReadContext: dataNetboxDcimPlatformRead,
 
 		Schema: map[string]*schema.Schema{
 			"content_type": {
@@ -34,7 +35,7 @@ func dataNetboxDcimPlatform() *schema.Resource {
 	}
 }
 
-func dataNetboxDcimPlatformRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxDcimPlatformRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	slug := d.Get("slug").(string)
@@ -43,14 +44,14 @@ func dataNetboxDcimPlatformRead(d *schema.ResourceData, m interface{}) error {
 
 	list, err := client.Dcim.DcimPlatformsList(resource, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if *list.Payload.Count < 1 {
-		return fmt.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " + 
 			"Please change your search criteria and try again.")
 	} else if *list.Payload.Count > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
+		return diag.Errorf("Your query returned more than one result. " +
 			"Please try a more specific search criteria.")
 	}
 

--- a/netbox/data_netbox_dcim_site.go
+++ b/netbox/data_netbox_dcim_site.go
@@ -1,10 +1,11 @@
 package netbox
 
 import (
-	"fmt"
+	"context"
 	"regexp"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
@@ -14,7 +15,7 @@ import (
 func dataNetboxDcimSite() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get info about site (dcim module) from netbox.",
-		Read:        dataNetboxDcimSiteRead,
+		ReadContext: dataNetboxDcimSiteRead,
 
 		Schema: map[string]*schema.Schema{
 			"content_type": {
@@ -34,7 +35,7 @@ func dataNetboxDcimSite() *schema.Resource {
 	}
 }
 
-func dataNetboxDcimSiteRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxDcimSiteRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	slug := d.Get("slug").(string)
@@ -43,14 +44,14 @@ func dataNetboxDcimSiteRead(d *schema.ResourceData, m interface{}) error {
 
 	list, err := client.Dcim.DcimSitesList(p, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if *list.Payload.Count < 1 {
-		return fmt.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	} else if *list.Payload.Count > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
+		return diag.Errorf("Your query returned more than one result. " +
 			"Please try a more specific search criteria.")
 	}
 

--- a/netbox/data_netbox_ipam_aggregate.go
+++ b/netbox/data_netbox_ipam_aggregate.go
@@ -1,9 +1,10 @@
 package netbox
 
 import (
-	"fmt"
+	"context"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
@@ -13,7 +14,7 @@ import (
 func dataNetboxIpamAggregate() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get info about aggregate (ipam module) from Netbox.",
-		Read:        dataNetboxIpamAggregateRead,
+		ReadContext: dataNetboxIpamAggregateRead,
 
 		Schema: map[string]*schema.Schema{
 			"content_type": {
@@ -36,8 +37,8 @@ func dataNetboxIpamAggregate() *schema.Resource {
 	}
 }
 
-func dataNetboxIpamAggregateRead(d *schema.ResourceData,
-	m interface{}) error {
+func dataNetboxIpamAggregateRead(ctx context.Context, d *schema.ResourceData,
+	m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	prefix := d.Get("prefix").(string)
@@ -47,14 +48,14 @@ func dataNetboxIpamAggregateRead(d *schema.ResourceData,
 
 	list, err := client.Ipam.IpamAggregatesList(p, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if *list.Payload.Count < 1 {
-		return fmt.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	} else if *list.Payload.Count > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
+		return diag.Errorf("Your query returned more than one result. " +
 			"Please try a more specific search criteria.")
 	}
 

--- a/netbox/data_netbox_ipam_ip_addresses.go
+++ b/netbox/data_netbox_ipam_ip_addresses.go
@@ -1,9 +1,10 @@
 package netbox
 
 import (
-	"fmt"
+	"context"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
@@ -13,7 +14,7 @@ import (
 func dataNetboxIpamIPAddresses() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get info about IP addresses (ipam module) from netbox.",
-		Read:        dataNetboxIpamIPAddressesRead,
+		ReadContext: dataNetboxIpamIPAddressesRead,
 
 		Schema: map[string]*schema.Schema{
 			"content_type": {
@@ -31,8 +32,8 @@ func dataNetboxIpamIPAddresses() *schema.Resource {
 	}
 }
 
-func dataNetboxIpamIPAddressesRead(d *schema.ResourceData,
-	m interface{}) error {
+func dataNetboxIpamIPAddressesRead(ctx context.Context, d *schema.ResourceData,
+	m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	address := d.Get("address").(string)
@@ -41,14 +42,14 @@ func dataNetboxIpamIPAddressesRead(d *schema.ResourceData,
 
 	list, err := client.Ipam.IpamIPAddressesList(p, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if *list.Payload.Count < 1 {
-		return fmt.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	} else if *list.Payload.Count > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
+		return diag.Errorf("Your query returned more than one result. " +
 			"Please try a more specific search criteria.")
 	}
 

--- a/netbox/data_netbox_ipam_role.go
+++ b/netbox/data_netbox_ipam_role.go
@@ -1,10 +1,11 @@
 package netbox
 
 import (
-	"fmt"
+	"context"
 	"regexp"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
@@ -14,7 +15,7 @@ import (
 func dataNetboxIpamRole() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get info about role (ipam module) from netbox.",
-		Read:        dataNetboxIpamRoleRead,
+		ReadContext: dataNetboxIpamRoleRead,
 
 		Schema: map[string]*schema.Schema{
 			"content_type": {
@@ -34,7 +35,7 @@ func dataNetboxIpamRole() *schema.Resource {
 	}
 }
 
-func dataNetboxIpamRoleRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxIpamRoleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	slug := d.Get("slug").(string)
@@ -43,14 +44,14 @@ func dataNetboxIpamRoleRead(d *schema.ResourceData, m interface{}) error {
 
 	list, err := client.Ipam.IpamRolesList(p, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if *list.Payload.Count < 1 {
-		return fmt.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	} else if *list.Payload.Count > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
+		return diag.Errorf("Your query returned more than one result. " +
 			"Please try a more specific search criteria.")
 	}
 

--- a/netbox/data_netbox_ipam_service.go
+++ b/netbox/data_netbox_ipam_service.go
@@ -1,9 +1,10 @@
 package netbox
 
 import (
-	"fmt"
+	"context"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
@@ -13,7 +14,7 @@ import (
 func dataNetboxIpamService() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get info about a service (ipam module) from netbox.",
-		Read:        dataNetboxIpamServiceRead,
+		ReadContext: dataNetboxIpamServiceRead,
 
 		Schema: map[string]*schema.Schema{
 			"content_type": {
@@ -55,8 +56,8 @@ func dataNetboxIpamService() *schema.Resource {
 	}
 }
 
-func dataNetboxIpamServiceRead(d *schema.ResourceData,
-	m interface{}) error {
+func dataNetboxIpamServiceRead(ctx context.Context, d *schema.ResourceData,
+	m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	deviceID := int64(d.Get("device_id").(int))
@@ -78,14 +79,14 @@ func dataNetboxIpamServiceRead(d *schema.ResourceData,
 
 	list, err := client.Ipam.IpamServicesList(p, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if *list.Payload.Count < 1 {
-		return fmt.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	} else if *list.Payload.Count > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
+		return diag.Errorf("Your query returned more than one result. " +
 			"Please try a more specific search criteria.")
 	}
 

--- a/netbox/data_netbox_ipam_vlan.go
+++ b/netbox/data_netbox_ipam_vlan.go
@@ -1,9 +1,10 @@
 package netbox
 
 import (
-	"fmt"
+	"context"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -12,7 +13,7 @@ import (
 func dataNetboxIpamVlan() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get info about vlan (ipam module) from netbox.",
-		Read:        dataNetboxIpamVlanRead,
+		ReadContext: dataNetboxIpamVlanRead,
 
 		Schema: map[string]*schema.Schema{
 			"content_type": {
@@ -34,7 +35,7 @@ func dataNetboxIpamVlan() *schema.Resource {
 	}
 }
 
-func dataNetboxIpamVlanRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxIpamVlanRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	id := int64(d.Get("vlan_id").(int))
@@ -49,14 +50,14 @@ func dataNetboxIpamVlanRead(d *schema.ResourceData, m interface{}) error {
 
 	list, err := client.Ipam.IpamVlansList(p, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if *list.Payload.Count < 1 {
-		return fmt.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	} else if *list.Payload.Count > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
+		return diag.Errorf("Your query returned more than one result. " +
 			"Please try a more specific search criteria.")
 	}
 

--- a/netbox/data_netbox_ipam_vlan_group.go
+++ b/netbox/data_netbox_ipam_vlan_group.go
@@ -1,10 +1,11 @@
 package netbox
 
 import (
-	"fmt"
+	"context"
 	"regexp"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
@@ -14,7 +15,7 @@ import (
 func dataNetboxIpamVlanGroup() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get info about a vlan group (ipam module) from netbox.",
-		Read:        dataNetboxIpamVlanGroupRead,
+		ReadContext: dataNetboxIpamVlanGroupRead,
 
 		Schema: map[string]*schema.Schema{
 			"content_type": {
@@ -34,7 +35,7 @@ func dataNetboxIpamVlanGroup() *schema.Resource {
 	}
 }
 
-func dataNetboxIpamVlanGroupRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxIpamVlanGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	slug := d.Get("slug").(string)
@@ -43,14 +44,14 @@ func dataNetboxIpamVlanGroupRead(d *schema.ResourceData, m interface{}) error {
 
 	list, err := client.Ipam.IpamVlanGroupsList(p, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if *list.Payload.Count < 1 {
-		return fmt.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	} else if *list.Payload.Count > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
+		return diag.Errorf("Your query returned more than one result. " +
 			"Please try a more specific search criteria.")
 	}
 

--- a/netbox/data_netbox_json_circuits_circuit_terminations_list.go
+++ b/netbox/data_netbox_json_circuits_circuit_terminations_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/circuits"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONCircuitsCircuitTerminationsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the circuits_circuit_terminations_list Netbox endpoint.",
-		Read:        dataNetboxJSONCircuitsCircuitTerminationsListRead,
+		ReadContext: dataNetboxJSONCircuitsCircuitTerminationsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONCircuitsCircuitTerminationsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONCircuitsCircuitTerminationsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONCircuitsCircuitTerminationsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := circuits.NewCircuitsCircuitTerminationsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONCircuitsCircuitTerminationsListRead(d *schema.ResourceData, m
 
 	list, err := client.Circuits.CircuitsCircuitTerminationsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_circuits_circuit_types_list.go
+++ b/netbox/data_netbox_json_circuits_circuit_types_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/circuits"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONCircuitsCircuitTypesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the circuits_circuit_types_list Netbox endpoint.",
-		Read:        dataNetboxJSONCircuitsCircuitTypesListRead,
+		ReadContext: dataNetboxJSONCircuitsCircuitTypesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONCircuitsCircuitTypesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONCircuitsCircuitTypesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONCircuitsCircuitTypesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := circuits.NewCircuitsCircuitTypesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONCircuitsCircuitTypesListRead(d *schema.ResourceData, m interf
 
 	list, err := client.Circuits.CircuitsCircuitTypesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_circuits_circuits_list.go
+++ b/netbox/data_netbox_json_circuits_circuits_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/circuits"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONCircuitsCircuitsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the circuits_circuits_list Netbox endpoint.",
-		Read:        dataNetboxJSONCircuitsCircuitsListRead,
+		ReadContext: dataNetboxJSONCircuitsCircuitsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONCircuitsCircuitsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONCircuitsCircuitsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONCircuitsCircuitsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := circuits.NewCircuitsCircuitsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONCircuitsCircuitsListRead(d *schema.ResourceData, m interface{
 
 	list, err := client.Circuits.CircuitsCircuitsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_circuits_provider_networks_list.go
+++ b/netbox/data_netbox_json_circuits_provider_networks_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/circuits"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONCircuitsProviderNetworksList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the circuits_provider_networks_list Netbox endpoint.",
-		Read:        dataNetboxJSONCircuitsProviderNetworksListRead,
+		ReadContext: dataNetboxJSONCircuitsProviderNetworksListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONCircuitsProviderNetworksList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONCircuitsProviderNetworksListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONCircuitsProviderNetworksListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := circuits.NewCircuitsProviderNetworksListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONCircuitsProviderNetworksListRead(d *schema.ResourceData, m in
 
 	list, err := client.Circuits.CircuitsProviderNetworksList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_circuits_providers_list.go
+++ b/netbox/data_netbox_json_circuits_providers_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/circuits"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONCircuitsProvidersList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the circuits_providers_list Netbox endpoint.",
-		Read:        dataNetboxJSONCircuitsProvidersListRead,
+		ReadContext: dataNetboxJSONCircuitsProvidersListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONCircuitsProvidersList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONCircuitsProvidersListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONCircuitsProvidersListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := circuits.NewCircuitsProvidersListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONCircuitsProvidersListRead(d *schema.ResourceData, m interface
 
 	list, err := client.Circuits.CircuitsProvidersList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_cables_list.go
+++ b/netbox/data_netbox_json_dcim_cables_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimCablesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_cables_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimCablesListRead,
+		ReadContext: dataNetboxJSONDcimCablesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimCablesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimCablesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimCablesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimCablesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimCablesListRead(d *schema.ResourceData, m interface{}) err
 
 	list, err := client.Dcim.DcimCablesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_console_port_templates_list.go
+++ b/netbox/data_netbox_json_dcim_console_port_templates_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimConsolePortTemplatesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_console_port_templates_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimConsolePortTemplatesListRead,
+		ReadContext: dataNetboxJSONDcimConsolePortTemplatesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimConsolePortTemplatesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimConsolePortTemplatesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimConsolePortTemplatesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimConsolePortTemplatesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimConsolePortTemplatesListRead(d *schema.ResourceData, m in
 
 	list, err := client.Dcim.DcimConsolePortTemplatesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_console_ports_list.go
+++ b/netbox/data_netbox_json_dcim_console_ports_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimConsolePortsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_console_ports_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimConsolePortsListRead,
+		ReadContext: dataNetboxJSONDcimConsolePortsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimConsolePortsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimConsolePortsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimConsolePortsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimConsolePortsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimConsolePortsListRead(d *schema.ResourceData, m interface{
 
 	list, err := client.Dcim.DcimConsolePortsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_console_server_port_templates_list.go
+++ b/netbox/data_netbox_json_dcim_console_server_port_templates_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimConsoleServerPortTemplatesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_console_server_port_templates_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimConsoleServerPortTemplatesListRead,
+		ReadContext: dataNetboxJSONDcimConsoleServerPortTemplatesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimConsoleServerPortTemplatesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimConsoleServerPortTemplatesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimConsoleServerPortTemplatesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimConsoleServerPortTemplatesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimConsoleServerPortTemplatesListRead(d *schema.ResourceData
 
 	list, err := client.Dcim.DcimConsoleServerPortTemplatesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_console_server_ports_list.go
+++ b/netbox/data_netbox_json_dcim_console_server_ports_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimConsoleServerPortsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_console_server_ports_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimConsoleServerPortsListRead,
+		ReadContext: dataNetboxJSONDcimConsoleServerPortsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimConsoleServerPortsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimConsoleServerPortsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimConsoleServerPortsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimConsoleServerPortsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimConsoleServerPortsListRead(d *schema.ResourceData, m inte
 
 	list, err := client.Dcim.DcimConsoleServerPortsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_device_bay_templates_list.go
+++ b/netbox/data_netbox_json_dcim_device_bay_templates_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimDeviceBayTemplatesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_device_bay_templates_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimDeviceBayTemplatesListRead,
+		ReadContext: dataNetboxJSONDcimDeviceBayTemplatesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimDeviceBayTemplatesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimDeviceBayTemplatesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimDeviceBayTemplatesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimDeviceBayTemplatesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimDeviceBayTemplatesListRead(d *schema.ResourceData, m inte
 
 	list, err := client.Dcim.DcimDeviceBayTemplatesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_device_bays_list.go
+++ b/netbox/data_netbox_json_dcim_device_bays_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimDeviceBaysList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_device_bays_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimDeviceBaysListRead,
+		ReadContext: dataNetboxJSONDcimDeviceBaysListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimDeviceBaysList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimDeviceBaysListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimDeviceBaysListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimDeviceBaysListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimDeviceBaysListRead(d *schema.ResourceData, m interface{})
 
 	list, err := client.Dcim.DcimDeviceBaysList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_device_roles_list.go
+++ b/netbox/data_netbox_json_dcim_device_roles_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimDeviceRolesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_device_roles_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimDeviceRolesListRead,
+		ReadContext: dataNetboxJSONDcimDeviceRolesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimDeviceRolesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimDeviceRolesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimDeviceRolesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimDeviceRolesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimDeviceRolesListRead(d *schema.ResourceData, m interface{}
 
 	list, err := client.Dcim.DcimDeviceRolesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_device_types_list.go
+++ b/netbox/data_netbox_json_dcim_device_types_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimDeviceTypesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_device_types_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimDeviceTypesListRead,
+		ReadContext: dataNetboxJSONDcimDeviceTypesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimDeviceTypesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimDeviceTypesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimDeviceTypesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimDeviceTypesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimDeviceTypesListRead(d *schema.ResourceData, m interface{}
 
 	list, err := client.Dcim.DcimDeviceTypesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_devices_list.go
+++ b/netbox/data_netbox_json_dcim_devices_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimDevicesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_devices_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimDevicesListRead,
+		ReadContext: dataNetboxJSONDcimDevicesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimDevicesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimDevicesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimDevicesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimDevicesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimDevicesListRead(d *schema.ResourceData, m interface{}) er
 
 	list, err := client.Dcim.DcimDevicesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_front_port_templates_list.go
+++ b/netbox/data_netbox_json_dcim_front_port_templates_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimFrontPortTemplatesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_front_port_templates_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimFrontPortTemplatesListRead,
+		ReadContext: dataNetboxJSONDcimFrontPortTemplatesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimFrontPortTemplatesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimFrontPortTemplatesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimFrontPortTemplatesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimFrontPortTemplatesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimFrontPortTemplatesListRead(d *schema.ResourceData, m inte
 
 	list, err := client.Dcim.DcimFrontPortTemplatesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_front_ports_list.go
+++ b/netbox/data_netbox_json_dcim_front_ports_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimFrontPortsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_front_ports_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimFrontPortsListRead,
+		ReadContext: dataNetboxJSONDcimFrontPortsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimFrontPortsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimFrontPortsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimFrontPortsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimFrontPortsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimFrontPortsListRead(d *schema.ResourceData, m interface{})
 
 	list, err := client.Dcim.DcimFrontPortsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_interface_templates_list.go
+++ b/netbox/data_netbox_json_dcim_interface_templates_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimInterfaceTemplatesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_interface_templates_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimInterfaceTemplatesListRead,
+		ReadContext: dataNetboxJSONDcimInterfaceTemplatesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimInterfaceTemplatesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimInterfaceTemplatesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimInterfaceTemplatesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimInterfaceTemplatesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimInterfaceTemplatesListRead(d *schema.ResourceData, m inte
 
 	list, err := client.Dcim.DcimInterfaceTemplatesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_interfaces_list.go
+++ b/netbox/data_netbox_json_dcim_interfaces_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimInterfacesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_interfaces_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimInterfacesListRead,
+		ReadContext: dataNetboxJSONDcimInterfacesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimInterfacesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimInterfacesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimInterfacesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimInterfacesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimInterfacesListRead(d *schema.ResourceData, m interface{})
 
 	list, err := client.Dcim.DcimInterfacesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_inventory_item_roles_list.go
+++ b/netbox/data_netbox_json_dcim_inventory_item_roles_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimInventoryItemRolesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_inventory_item_roles_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimInventoryItemRolesListRead,
+		ReadContext: dataNetboxJSONDcimInventoryItemRolesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimInventoryItemRolesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimInventoryItemRolesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimInventoryItemRolesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimInventoryItemRolesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimInventoryItemRolesListRead(d *schema.ResourceData, m inte
 
 	list, err := client.Dcim.DcimInventoryItemRolesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_inventory_item_templates_list.go
+++ b/netbox/data_netbox_json_dcim_inventory_item_templates_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimInventoryItemTemplatesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_inventory_item_templates_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimInventoryItemTemplatesListRead,
+		ReadContext: dataNetboxJSONDcimInventoryItemTemplatesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimInventoryItemTemplatesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimInventoryItemTemplatesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimInventoryItemTemplatesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimInventoryItemTemplatesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimInventoryItemTemplatesListRead(d *schema.ResourceData, m 
 
 	list, err := client.Dcim.DcimInventoryItemTemplatesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_inventory_items_list.go
+++ b/netbox/data_netbox_json_dcim_inventory_items_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimInventoryItemsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_inventory_items_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimInventoryItemsListRead,
+		ReadContext: dataNetboxJSONDcimInventoryItemsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimInventoryItemsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimInventoryItemsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimInventoryItemsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimInventoryItemsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimInventoryItemsListRead(d *schema.ResourceData, m interfac
 
 	list, err := client.Dcim.DcimInventoryItemsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_locations_list.go
+++ b/netbox/data_netbox_json_dcim_locations_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimLocationsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_locations_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimLocationsListRead,
+		ReadContext: dataNetboxJSONDcimLocationsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimLocationsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimLocationsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimLocationsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimLocationsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimLocationsListRead(d *schema.ResourceData, m interface{}) 
 
 	list, err := client.Dcim.DcimLocationsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_manufacturers_list.go
+++ b/netbox/data_netbox_json_dcim_manufacturers_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimManufacturersList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_manufacturers_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimManufacturersListRead,
+		ReadContext: dataNetboxJSONDcimManufacturersListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimManufacturersList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimManufacturersListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimManufacturersListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimManufacturersListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimManufacturersListRead(d *schema.ResourceData, m interface
 
 	list, err := client.Dcim.DcimManufacturersList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_module_bay_templates_list.go
+++ b/netbox/data_netbox_json_dcim_module_bay_templates_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimModuleBayTemplatesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_module_bay_templates_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimModuleBayTemplatesListRead,
+		ReadContext: dataNetboxJSONDcimModuleBayTemplatesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimModuleBayTemplatesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimModuleBayTemplatesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimModuleBayTemplatesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimModuleBayTemplatesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimModuleBayTemplatesListRead(d *schema.ResourceData, m inte
 
 	list, err := client.Dcim.DcimModuleBayTemplatesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_module_bays_list.go
+++ b/netbox/data_netbox_json_dcim_module_bays_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimModuleBaysList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_module_bays_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimModuleBaysListRead,
+		ReadContext: dataNetboxJSONDcimModuleBaysListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimModuleBaysList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimModuleBaysListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimModuleBaysListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimModuleBaysListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimModuleBaysListRead(d *schema.ResourceData, m interface{})
 
 	list, err := client.Dcim.DcimModuleBaysList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_module_types_list.go
+++ b/netbox/data_netbox_json_dcim_module_types_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimModuleTypesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_module_types_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimModuleTypesListRead,
+		ReadContext: dataNetboxJSONDcimModuleTypesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimModuleTypesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimModuleTypesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimModuleTypesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimModuleTypesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimModuleTypesListRead(d *schema.ResourceData, m interface{}
 
 	list, err := client.Dcim.DcimModuleTypesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_modules_list.go
+++ b/netbox/data_netbox_json_dcim_modules_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimModulesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_modules_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimModulesListRead,
+		ReadContext: dataNetboxJSONDcimModulesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimModulesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimModulesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimModulesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimModulesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimModulesListRead(d *schema.ResourceData, m interface{}) er
 
 	list, err := client.Dcim.DcimModulesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_platforms_list.go
+++ b/netbox/data_netbox_json_dcim_platforms_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimPlatformsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_platforms_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimPlatformsListRead,
+		ReadContext: dataNetboxJSONDcimPlatformsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimPlatformsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimPlatformsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimPlatformsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimPlatformsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimPlatformsListRead(d *schema.ResourceData, m interface{}) 
 
 	list, err := client.Dcim.DcimPlatformsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_power_feeds_list.go
+++ b/netbox/data_netbox_json_dcim_power_feeds_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimPowerFeedsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_power_feeds_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimPowerFeedsListRead,
+		ReadContext: dataNetboxJSONDcimPowerFeedsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimPowerFeedsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimPowerFeedsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimPowerFeedsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimPowerFeedsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimPowerFeedsListRead(d *schema.ResourceData, m interface{})
 
 	list, err := client.Dcim.DcimPowerFeedsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_power_outlet_templates_list.go
+++ b/netbox/data_netbox_json_dcim_power_outlet_templates_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimPowerOutletTemplatesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_power_outlet_templates_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimPowerOutletTemplatesListRead,
+		ReadContext: dataNetboxJSONDcimPowerOutletTemplatesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimPowerOutletTemplatesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimPowerOutletTemplatesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimPowerOutletTemplatesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimPowerOutletTemplatesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimPowerOutletTemplatesListRead(d *schema.ResourceData, m in
 
 	list, err := client.Dcim.DcimPowerOutletTemplatesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_power_outlets_list.go
+++ b/netbox/data_netbox_json_dcim_power_outlets_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimPowerOutletsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_power_outlets_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimPowerOutletsListRead,
+		ReadContext: dataNetboxJSONDcimPowerOutletsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimPowerOutletsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimPowerOutletsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimPowerOutletsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimPowerOutletsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimPowerOutletsListRead(d *schema.ResourceData, m interface{
 
 	list, err := client.Dcim.DcimPowerOutletsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_power_panels_list.go
+++ b/netbox/data_netbox_json_dcim_power_panels_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimPowerPanelsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_power_panels_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimPowerPanelsListRead,
+		ReadContext: dataNetboxJSONDcimPowerPanelsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimPowerPanelsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimPowerPanelsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimPowerPanelsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimPowerPanelsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimPowerPanelsListRead(d *schema.ResourceData, m interface{}
 
 	list, err := client.Dcim.DcimPowerPanelsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_power_port_templates_list.go
+++ b/netbox/data_netbox_json_dcim_power_port_templates_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimPowerPortTemplatesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_power_port_templates_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimPowerPortTemplatesListRead,
+		ReadContext: dataNetboxJSONDcimPowerPortTemplatesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimPowerPortTemplatesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimPowerPortTemplatesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimPowerPortTemplatesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimPowerPortTemplatesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimPowerPortTemplatesListRead(d *schema.ResourceData, m inte
 
 	list, err := client.Dcim.DcimPowerPortTemplatesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_power_ports_list.go
+++ b/netbox/data_netbox_json_dcim_power_ports_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimPowerPortsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_power_ports_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimPowerPortsListRead,
+		ReadContext: dataNetboxJSONDcimPowerPortsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimPowerPortsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimPowerPortsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimPowerPortsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimPowerPortsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimPowerPortsListRead(d *schema.ResourceData, m interface{})
 
 	list, err := client.Dcim.DcimPowerPortsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_rack_reservations_list.go
+++ b/netbox/data_netbox_json_dcim_rack_reservations_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimRackReservationsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_rack_reservations_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimRackReservationsListRead,
+		ReadContext: dataNetboxJSONDcimRackReservationsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimRackReservationsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimRackReservationsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimRackReservationsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimRackReservationsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimRackReservationsListRead(d *schema.ResourceData, m interf
 
 	list, err := client.Dcim.DcimRackReservationsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_rack_roles_list.go
+++ b/netbox/data_netbox_json_dcim_rack_roles_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimRackRolesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_rack_roles_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimRackRolesListRead,
+		ReadContext: dataNetboxJSONDcimRackRolesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimRackRolesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimRackRolesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimRackRolesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimRackRolesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimRackRolesListRead(d *schema.ResourceData, m interface{}) 
 
 	list, err := client.Dcim.DcimRackRolesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_racks_list.go
+++ b/netbox/data_netbox_json_dcim_racks_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimRacksList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_racks_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimRacksListRead,
+		ReadContext: dataNetboxJSONDcimRacksListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimRacksList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimRacksListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimRacksListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimRacksListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimRacksListRead(d *schema.ResourceData, m interface{}) erro
 
 	list, err := client.Dcim.DcimRacksList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_rear_port_templates_list.go
+++ b/netbox/data_netbox_json_dcim_rear_port_templates_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimRearPortTemplatesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_rear_port_templates_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimRearPortTemplatesListRead,
+		ReadContext: dataNetboxJSONDcimRearPortTemplatesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimRearPortTemplatesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimRearPortTemplatesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimRearPortTemplatesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimRearPortTemplatesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimRearPortTemplatesListRead(d *schema.ResourceData, m inter
 
 	list, err := client.Dcim.DcimRearPortTemplatesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_rear_ports_list.go
+++ b/netbox/data_netbox_json_dcim_rear_ports_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimRearPortsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_rear_ports_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimRearPortsListRead,
+		ReadContext: dataNetboxJSONDcimRearPortsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimRearPortsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimRearPortsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimRearPortsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimRearPortsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimRearPortsListRead(d *schema.ResourceData, m interface{}) 
 
 	list, err := client.Dcim.DcimRearPortsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_regions_list.go
+++ b/netbox/data_netbox_json_dcim_regions_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimRegionsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_regions_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimRegionsListRead,
+		ReadContext: dataNetboxJSONDcimRegionsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimRegionsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimRegionsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimRegionsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimRegionsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimRegionsListRead(d *schema.ResourceData, m interface{}) er
 
 	list, err := client.Dcim.DcimRegionsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_site_groups_list.go
+++ b/netbox/data_netbox_json_dcim_site_groups_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimSiteGroupsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_site_groups_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimSiteGroupsListRead,
+		ReadContext: dataNetboxJSONDcimSiteGroupsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimSiteGroupsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimSiteGroupsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimSiteGroupsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimSiteGroupsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimSiteGroupsListRead(d *schema.ResourceData, m interface{})
 
 	list, err := client.Dcim.DcimSiteGroupsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_sites_list.go
+++ b/netbox/data_netbox_json_dcim_sites_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimSitesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_sites_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimSitesListRead,
+		ReadContext: dataNetboxJSONDcimSitesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimSitesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimSitesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimSitesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimSitesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimSitesListRead(d *schema.ResourceData, m interface{}) erro
 
 	list, err := client.Dcim.DcimSitesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_dcim_virtual_chassis_list.go
+++ b/netbox/data_netbox_json_dcim_virtual_chassis_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/dcim"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONDcimVirtualChassisList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the dcim_virtual_chassis_list Netbox endpoint.",
-		Read:        dataNetboxJSONDcimVirtualChassisListRead,
+		ReadContext: dataNetboxJSONDcimVirtualChassisListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONDcimVirtualChassisList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONDcimVirtualChassisListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONDcimVirtualChassisListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := dcim.NewDcimVirtualChassisListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONDcimVirtualChassisListRead(d *schema.ResourceData, m interfac
 
 	list, err := client.Dcim.DcimVirtualChassisList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_extras_config_contexts_list.go
+++ b/netbox/data_netbox_json_extras_config_contexts_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/extras"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONExtrasConfigContextsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the extras_config_contexts_list Netbox endpoint.",
-		Read:        dataNetboxJSONExtrasConfigContextsListRead,
+		ReadContext: dataNetboxJSONExtrasConfigContextsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONExtrasConfigContextsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONExtrasConfigContextsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONExtrasConfigContextsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := extras.NewExtrasConfigContextsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONExtrasConfigContextsListRead(d *schema.ResourceData, m interf
 
 	list, err := client.Extras.ExtrasConfigContextsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_extras_content_types_list.go
+++ b/netbox/data_netbox_json_extras_content_types_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/extras"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONExtrasContentTypesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the extras_content_types_list Netbox endpoint.",
-		Read:        dataNetboxJSONExtrasContentTypesListRead,
+		ReadContext: dataNetboxJSONExtrasContentTypesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONExtrasContentTypesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONExtrasContentTypesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONExtrasContentTypesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := extras.NewExtrasContentTypesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONExtrasContentTypesListRead(d *schema.ResourceData, m interfac
 
 	list, err := client.Extras.ExtrasContentTypesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_extras_custom_fields_list.go
+++ b/netbox/data_netbox_json_extras_custom_fields_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/extras"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONExtrasCustomFieldsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the extras_custom_fields_list Netbox endpoint.",
-		Read:        dataNetboxJSONExtrasCustomFieldsListRead,
+		ReadContext: dataNetboxJSONExtrasCustomFieldsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONExtrasCustomFieldsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONExtrasCustomFieldsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONExtrasCustomFieldsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := extras.NewExtrasCustomFieldsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONExtrasCustomFieldsListRead(d *schema.ResourceData, m interfac
 
 	list, err := client.Extras.ExtrasCustomFieldsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_extras_custom_links_list.go
+++ b/netbox/data_netbox_json_extras_custom_links_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/extras"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONExtrasCustomLinksList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the extras_custom_links_list Netbox endpoint.",
-		Read:        dataNetboxJSONExtrasCustomLinksListRead,
+		ReadContext: dataNetboxJSONExtrasCustomLinksListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONExtrasCustomLinksList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONExtrasCustomLinksListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONExtrasCustomLinksListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := extras.NewExtrasCustomLinksListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONExtrasCustomLinksListRead(d *schema.ResourceData, m interface
 
 	list, err := client.Extras.ExtrasCustomLinksList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_extras_export_templates_list.go
+++ b/netbox/data_netbox_json_extras_export_templates_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/extras"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONExtrasExportTemplatesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the extras_export_templates_list Netbox endpoint.",
-		Read:        dataNetboxJSONExtrasExportTemplatesListRead,
+		ReadContext: dataNetboxJSONExtrasExportTemplatesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONExtrasExportTemplatesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONExtrasExportTemplatesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONExtrasExportTemplatesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := extras.NewExtrasExportTemplatesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONExtrasExportTemplatesListRead(d *schema.ResourceData, m inter
 
 	list, err := client.Extras.ExtrasExportTemplatesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_extras_image_attachments_list.go
+++ b/netbox/data_netbox_json_extras_image_attachments_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/extras"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONExtrasImageAttachmentsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the extras_image_attachments_list Netbox endpoint.",
-		Read:        dataNetboxJSONExtrasImageAttachmentsListRead,
+		ReadContext: dataNetboxJSONExtrasImageAttachmentsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONExtrasImageAttachmentsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONExtrasImageAttachmentsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONExtrasImageAttachmentsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := extras.NewExtrasImageAttachmentsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONExtrasImageAttachmentsListRead(d *schema.ResourceData, m inte
 
 	list, err := client.Extras.ExtrasImageAttachmentsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_extras_job_results_list.go
+++ b/netbox/data_netbox_json_extras_job_results_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/extras"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONExtrasJobResultsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the extras_job_results_list Netbox endpoint.",
-		Read:        dataNetboxJSONExtrasJobResultsListRead,
+		ReadContext: dataNetboxJSONExtrasJobResultsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONExtrasJobResultsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONExtrasJobResultsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONExtrasJobResultsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := extras.NewExtrasJobResultsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONExtrasJobResultsListRead(d *schema.ResourceData, m interface{
 
 	list, err := client.Extras.ExtrasJobResultsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_extras_journal_entries_list.go
+++ b/netbox/data_netbox_json_extras_journal_entries_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/extras"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONExtrasJournalEntriesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the extras_journal_entries_list Netbox endpoint.",
-		Read:        dataNetboxJSONExtrasJournalEntriesListRead,
+		ReadContext: dataNetboxJSONExtrasJournalEntriesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONExtrasJournalEntriesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONExtrasJournalEntriesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONExtrasJournalEntriesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := extras.NewExtrasJournalEntriesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONExtrasJournalEntriesListRead(d *schema.ResourceData, m interf
 
 	list, err := client.Extras.ExtrasJournalEntriesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_extras_object_changes_list.go
+++ b/netbox/data_netbox_json_extras_object_changes_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/extras"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONExtrasObjectChangesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the extras_object_changes_list Netbox endpoint.",
-		Read:        dataNetboxJSONExtrasObjectChangesListRead,
+		ReadContext: dataNetboxJSONExtrasObjectChangesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONExtrasObjectChangesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONExtrasObjectChangesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONExtrasObjectChangesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := extras.NewExtrasObjectChangesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONExtrasObjectChangesListRead(d *schema.ResourceData, m interfa
 
 	list, err := client.Extras.ExtrasObjectChangesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_extras_tags_list.go
+++ b/netbox/data_netbox_json_extras_tags_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/extras"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONExtrasTagsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the extras_tags_list Netbox endpoint.",
-		Read:        dataNetboxJSONExtrasTagsListRead,
+		ReadContext: dataNetboxJSONExtrasTagsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONExtrasTagsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONExtrasTagsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONExtrasTagsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := extras.NewExtrasTagsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONExtrasTagsListRead(d *schema.ResourceData, m interface{}) err
 
 	list, err := client.Extras.ExtrasTagsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_extras_webhooks_list.go
+++ b/netbox/data_netbox_json_extras_webhooks_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/extras"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONExtrasWebhooksList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the extras_webhooks_list Netbox endpoint.",
-		Read:        dataNetboxJSONExtrasWebhooksListRead,
+		ReadContext: dataNetboxJSONExtrasWebhooksListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONExtrasWebhooksList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONExtrasWebhooksListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONExtrasWebhooksListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := extras.NewExtrasWebhooksListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONExtrasWebhooksListRead(d *schema.ResourceData, m interface{})
 
 	list, err := client.Extras.ExtrasWebhooksList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_aggregates_list.go
+++ b/netbox/data_netbox_json_ipam_aggregates_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamAggregatesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_aggregates_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamAggregatesListRead,
+		ReadContext: dataNetboxJSONIpamAggregatesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamAggregatesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamAggregatesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamAggregatesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamAggregatesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamAggregatesListRead(d *schema.ResourceData, m interface{})
 
 	list, err := client.Ipam.IpamAggregatesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_asns_list.go
+++ b/netbox/data_netbox_json_ipam_asns_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamAsnsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_asns_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamAsnsListRead,
+		ReadContext: dataNetboxJSONIpamAsnsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamAsnsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamAsnsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamAsnsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamAsnsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamAsnsListRead(d *schema.ResourceData, m interface{}) error
 
 	list, err := client.Ipam.IpamAsnsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_fhrp_group_assignments_list.go
+++ b/netbox/data_netbox_json_ipam_fhrp_group_assignments_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamFhrpGroupAssignmentsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_fhrp_group_assignments_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamFhrpGroupAssignmentsListRead,
+		ReadContext: dataNetboxJSONIpamFhrpGroupAssignmentsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamFhrpGroupAssignmentsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamFhrpGroupAssignmentsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamFhrpGroupAssignmentsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamFhrpGroupAssignmentsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamFhrpGroupAssignmentsListRead(d *schema.ResourceData, m in
 
 	list, err := client.Ipam.IpamFhrpGroupAssignmentsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_fhrp_groups_list.go
+++ b/netbox/data_netbox_json_ipam_fhrp_groups_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamFhrpGroupsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_fhrp_groups_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamFhrpGroupsListRead,
+		ReadContext: dataNetboxJSONIpamFhrpGroupsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamFhrpGroupsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamFhrpGroupsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamFhrpGroupsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamFhrpGroupsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamFhrpGroupsListRead(d *schema.ResourceData, m interface{})
 
 	list, err := client.Ipam.IpamFhrpGroupsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_ip_addresses_list.go
+++ b/netbox/data_netbox_json_ipam_ip_addresses_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamIPAddressesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_ip_addresses_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamIPAddressesListRead,
+		ReadContext: dataNetboxJSONIpamIPAddressesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamIPAddressesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamIPAddressesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamIPAddressesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamIPAddressesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamIPAddressesListRead(d *schema.ResourceData, m interface{}
 
 	list, err := client.Ipam.IpamIPAddressesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_ip_ranges_list.go
+++ b/netbox/data_netbox_json_ipam_ip_ranges_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamIPRangesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_ip_ranges_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamIPRangesListRead,
+		ReadContext: dataNetboxJSONIpamIPRangesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamIPRangesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamIPRangesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamIPRangesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamIPRangesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamIPRangesListRead(d *schema.ResourceData, m interface{}) e
 
 	list, err := client.Ipam.IpamIPRangesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_prefixes_list.go
+++ b/netbox/data_netbox_json_ipam_prefixes_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamPrefixesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_prefixes_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamPrefixesListRead,
+		ReadContext: dataNetboxJSONIpamPrefixesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamPrefixesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamPrefixesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamPrefixesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamPrefixesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamPrefixesListRead(d *schema.ResourceData, m interface{}) e
 
 	list, err := client.Ipam.IpamPrefixesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_rirs_list.go
+++ b/netbox/data_netbox_json_ipam_rirs_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamRirsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_rirs_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamRirsListRead,
+		ReadContext: dataNetboxJSONIpamRirsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamRirsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamRirsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamRirsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamRirsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamRirsListRead(d *schema.ResourceData, m interface{}) error
 
 	list, err := client.Ipam.IpamRirsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_roles_list.go
+++ b/netbox/data_netbox_json_ipam_roles_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamRolesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_roles_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamRolesListRead,
+		ReadContext: dataNetboxJSONIpamRolesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamRolesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamRolesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamRolesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamRolesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamRolesListRead(d *schema.ResourceData, m interface{}) erro
 
 	list, err := client.Ipam.IpamRolesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_route_targets_list.go
+++ b/netbox/data_netbox_json_ipam_route_targets_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamRouteTargetsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_route_targets_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamRouteTargetsListRead,
+		ReadContext: dataNetboxJSONIpamRouteTargetsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamRouteTargetsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamRouteTargetsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamRouteTargetsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamRouteTargetsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamRouteTargetsListRead(d *schema.ResourceData, m interface{
 
 	list, err := client.Ipam.IpamRouteTargetsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_service_templates_list.go
+++ b/netbox/data_netbox_json_ipam_service_templates_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamServiceTemplatesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_service_templates_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamServiceTemplatesListRead,
+		ReadContext: dataNetboxJSONIpamServiceTemplatesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamServiceTemplatesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamServiceTemplatesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamServiceTemplatesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamServiceTemplatesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamServiceTemplatesListRead(d *schema.ResourceData, m interf
 
 	list, err := client.Ipam.IpamServiceTemplatesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_services_list.go
+++ b/netbox/data_netbox_json_ipam_services_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamServicesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_services_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamServicesListRead,
+		ReadContext: dataNetboxJSONIpamServicesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamServicesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamServicesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamServicesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamServicesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamServicesListRead(d *schema.ResourceData, m interface{}) e
 
 	list, err := client.Ipam.IpamServicesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_vlan_groups_list.go
+++ b/netbox/data_netbox_json_ipam_vlan_groups_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamVlanGroupsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_vlan_groups_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamVlanGroupsListRead,
+		ReadContext: dataNetboxJSONIpamVlanGroupsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamVlanGroupsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamVlanGroupsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamVlanGroupsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamVlanGroupsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamVlanGroupsListRead(d *schema.ResourceData, m interface{})
 
 	list, err := client.Ipam.IpamVlanGroupsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_vlans_list.go
+++ b/netbox/data_netbox_json_ipam_vlans_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamVlansList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_vlans_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamVlansListRead,
+		ReadContext: dataNetboxJSONIpamVlansListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamVlansList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamVlansListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamVlansListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamVlansListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamVlansListRead(d *schema.ResourceData, m interface{}) erro
 
 	list, err := client.Ipam.IpamVlansList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_ipam_vrfs_list.go
+++ b/netbox/data_netbox_json_ipam_vrfs_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/ipam"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONIpamVrfsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ipam_vrfs_list Netbox endpoint.",
-		Read:        dataNetboxJSONIpamVrfsListRead,
+		ReadContext: dataNetboxJSONIpamVrfsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONIpamVrfsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONIpamVrfsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONIpamVrfsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ipam.NewIpamVrfsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONIpamVrfsListRead(d *schema.ResourceData, m interface{}) error
 
 	list, err := client.Ipam.IpamVrfsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_tenancy_contact_assignments_list.go
+++ b/netbox/data_netbox_json_tenancy_contact_assignments_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/tenancy"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONTenancyContactAssignmentsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the tenancy_contact_assignments_list Netbox endpoint.",
-		Read:        dataNetboxJSONTenancyContactAssignmentsListRead,
+		ReadContext: dataNetboxJSONTenancyContactAssignmentsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONTenancyContactAssignmentsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONTenancyContactAssignmentsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONTenancyContactAssignmentsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := tenancy.NewTenancyContactAssignmentsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONTenancyContactAssignmentsListRead(d *schema.ResourceData, m i
 
 	list, err := client.Tenancy.TenancyContactAssignmentsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_tenancy_contact_groups_list.go
+++ b/netbox/data_netbox_json_tenancy_contact_groups_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/tenancy"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONTenancyContactGroupsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the tenancy_contact_groups_list Netbox endpoint.",
-		Read:        dataNetboxJSONTenancyContactGroupsListRead,
+		ReadContext: dataNetboxJSONTenancyContactGroupsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONTenancyContactGroupsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONTenancyContactGroupsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONTenancyContactGroupsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := tenancy.NewTenancyContactGroupsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONTenancyContactGroupsListRead(d *schema.ResourceData, m interf
 
 	list, err := client.Tenancy.TenancyContactGroupsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_tenancy_contact_roles_list.go
+++ b/netbox/data_netbox_json_tenancy_contact_roles_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/tenancy"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONTenancyContactRolesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the tenancy_contact_roles_list Netbox endpoint.",
-		Read:        dataNetboxJSONTenancyContactRolesListRead,
+		ReadContext: dataNetboxJSONTenancyContactRolesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONTenancyContactRolesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONTenancyContactRolesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONTenancyContactRolesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := tenancy.NewTenancyContactRolesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONTenancyContactRolesListRead(d *schema.ResourceData, m interfa
 
 	list, err := client.Tenancy.TenancyContactRolesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_tenancy_contacts_list.go
+++ b/netbox/data_netbox_json_tenancy_contacts_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/tenancy"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONTenancyContactsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the tenancy_contacts_list Netbox endpoint.",
-		Read:        dataNetboxJSONTenancyContactsListRead,
+		ReadContext: dataNetboxJSONTenancyContactsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONTenancyContactsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONTenancyContactsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONTenancyContactsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := tenancy.NewTenancyContactsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONTenancyContactsListRead(d *schema.ResourceData, m interface{}
 
 	list, err := client.Tenancy.TenancyContactsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_tenancy_tenant_groups_list.go
+++ b/netbox/data_netbox_json_tenancy_tenant_groups_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/tenancy"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONTenancyTenantGroupsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the tenancy_tenant_groups_list Netbox endpoint.",
-		Read:        dataNetboxJSONTenancyTenantGroupsListRead,
+		ReadContext: dataNetboxJSONTenancyTenantGroupsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONTenancyTenantGroupsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONTenancyTenantGroupsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONTenancyTenantGroupsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := tenancy.NewTenancyTenantGroupsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONTenancyTenantGroupsListRead(d *schema.ResourceData, m interfa
 
 	list, err := client.Tenancy.TenancyTenantGroupsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_tenancy_tenants_list.go
+++ b/netbox/data_netbox_json_tenancy_tenants_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/tenancy"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONTenancyTenantsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the tenancy_tenants_list Netbox endpoint.",
-		Read:        dataNetboxJSONTenancyTenantsListRead,
+		ReadContext: dataNetboxJSONTenancyTenantsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONTenancyTenantsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONTenancyTenantsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONTenancyTenantsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := tenancy.NewTenancyTenantsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONTenancyTenantsListRead(d *schema.ResourceData, m interface{})
 
 	list, err := client.Tenancy.TenancyTenantsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_users_groups_list.go
+++ b/netbox/data_netbox_json_users_groups_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/users"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONUsersGroupsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the users_groups_list Netbox endpoint.",
-		Read:        dataNetboxJSONUsersGroupsListRead,
+		ReadContext: dataNetboxJSONUsersGroupsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONUsersGroupsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONUsersGroupsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONUsersGroupsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := users.NewUsersGroupsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONUsersGroupsListRead(d *schema.ResourceData, m interface{}) er
 
 	list, err := client.Users.UsersGroupsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_users_permissions_list.go
+++ b/netbox/data_netbox_json_users_permissions_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/users"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONUsersPermissionsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the users_permissions_list Netbox endpoint.",
-		Read:        dataNetboxJSONUsersPermissionsListRead,
+		ReadContext: dataNetboxJSONUsersPermissionsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONUsersPermissionsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONUsersPermissionsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONUsersPermissionsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := users.NewUsersPermissionsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONUsersPermissionsListRead(d *schema.ResourceData, m interface{
 
 	list, err := client.Users.UsersPermissionsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_users_tokens_list.go
+++ b/netbox/data_netbox_json_users_tokens_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/users"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONUsersTokensList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the users_tokens_list Netbox endpoint.",
-		Read:        dataNetboxJSONUsersTokensListRead,
+		ReadContext: dataNetboxJSONUsersTokensListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONUsersTokensList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONUsersTokensListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONUsersTokensListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := users.NewUsersTokensListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONUsersTokensListRead(d *schema.ResourceData, m interface{}) er
 
 	list, err := client.Users.UsersTokensList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_users_users_list.go
+++ b/netbox/data_netbox_json_users_users_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/users"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONUsersUsersList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the users_users_list Netbox endpoint.",
-		Read:        dataNetboxJSONUsersUsersListRead,
+		ReadContext: dataNetboxJSONUsersUsersListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONUsersUsersList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONUsersUsersListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONUsersUsersListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := users.NewUsersUsersListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONUsersUsersListRead(d *schema.ResourceData, m interface{}) err
 
 	list, err := client.Users.UsersUsersList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_virtualization_cluster_groups_list.go
+++ b/netbox/data_netbox_json_virtualization_cluster_groups_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/virtualization"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONVirtualizationClusterGroupsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the virtualization_cluster_groups_list Netbox endpoint.",
-		Read:        dataNetboxJSONVirtualizationClusterGroupsListRead,
+		ReadContext: dataNetboxJSONVirtualizationClusterGroupsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONVirtualizationClusterGroupsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONVirtualizationClusterGroupsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONVirtualizationClusterGroupsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := virtualization.NewVirtualizationClusterGroupsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONVirtualizationClusterGroupsListRead(d *schema.ResourceData, m
 
 	list, err := client.Virtualization.VirtualizationClusterGroupsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_virtualization_cluster_types_list.go
+++ b/netbox/data_netbox_json_virtualization_cluster_types_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/virtualization"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONVirtualizationClusterTypesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the virtualization_cluster_types_list Netbox endpoint.",
-		Read:        dataNetboxJSONVirtualizationClusterTypesListRead,
+		ReadContext: dataNetboxJSONVirtualizationClusterTypesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONVirtualizationClusterTypesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONVirtualizationClusterTypesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONVirtualizationClusterTypesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := virtualization.NewVirtualizationClusterTypesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONVirtualizationClusterTypesListRead(d *schema.ResourceData, m 
 
 	list, err := client.Virtualization.VirtualizationClusterTypesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_virtualization_clusters_list.go
+++ b/netbox/data_netbox_json_virtualization_clusters_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/virtualization"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONVirtualizationClustersList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the virtualization_clusters_list Netbox endpoint.",
-		Read:        dataNetboxJSONVirtualizationClustersListRead,
+		ReadContext: dataNetboxJSONVirtualizationClustersListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONVirtualizationClustersList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONVirtualizationClustersListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONVirtualizationClustersListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := virtualization.NewVirtualizationClustersListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONVirtualizationClustersListRead(d *schema.ResourceData, m inte
 
 	list, err := client.Virtualization.VirtualizationClustersList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_virtualization_interfaces_list.go
+++ b/netbox/data_netbox_json_virtualization_interfaces_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/virtualization"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONVirtualizationInterfacesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the virtualization_interfaces_list Netbox endpoint.",
-		Read:        dataNetboxJSONVirtualizationInterfacesListRead,
+		ReadContext: dataNetboxJSONVirtualizationInterfacesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONVirtualizationInterfacesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONVirtualizationInterfacesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONVirtualizationInterfacesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := virtualization.NewVirtualizationInterfacesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONVirtualizationInterfacesListRead(d *schema.ResourceData, m in
 
 	list, err := client.Virtualization.VirtualizationInterfacesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_virtualization_virtual_machines_list.go
+++ b/netbox/data_netbox_json_virtualization_virtual_machines_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/virtualization"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONVirtualizationVirtualMachinesList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the virtualization_virtual_machines_list Netbox endpoint.",
-		Read:        dataNetboxJSONVirtualizationVirtualMachinesListRead,
+		ReadContext: dataNetboxJSONVirtualizationVirtualMachinesListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONVirtualizationVirtualMachinesList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONVirtualizationVirtualMachinesListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONVirtualizationVirtualMachinesListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := virtualization.NewVirtualizationVirtualMachinesListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONVirtualizationVirtualMachinesListRead(d *schema.ResourceData,
 
 	list, err := client.Virtualization.VirtualizationVirtualMachinesList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_wireless_wireless_lan_groups_list.go
+++ b/netbox/data_netbox_json_wireless_wireless_lan_groups_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/wireless"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONWirelessWirelessLanGroupsList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the wireless_wireless_lan_groups_list Netbox endpoint.",
-		Read:        dataNetboxJSONWirelessWirelessLanGroupsListRead,
+		ReadContext: dataNetboxJSONWirelessWirelessLanGroupsListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONWirelessWirelessLanGroupsList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONWirelessWirelessLanGroupsListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONWirelessWirelessLanGroupsListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := wireless.NewWirelessWirelessLanGroupsListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONWirelessWirelessLanGroupsListRead(d *schema.ResourceData, m i
 
 	list, err := client.Wireless.WirelessWirelessLanGroupsList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_wireless_wireless_lans_list.go
+++ b/netbox/data_netbox_json_wireless_wireless_lans_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/wireless"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONWirelessWirelessLansList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the wireless_wireless_lans_list Netbox endpoint.",
-		Read:        dataNetboxJSONWirelessWirelessLansListRead,
+		ReadContext: dataNetboxJSONWirelessWirelessLansListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONWirelessWirelessLansList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONWirelessWirelessLansListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONWirelessWirelessLansListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := wireless.NewWirelessWirelessLansListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONWirelessWirelessLansListRead(d *schema.ResourceData, m interf
 
 	list, err := client.Wireless.WirelessWirelessLansList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_json_wireless_wireless_links_list.go
+++ b/netbox/data_netbox_json_wireless_wireless_links_list.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
 	"github.com/smutel/go-netbox/netbox/client/wireless"
@@ -11,7 +13,7 @@ import (
 func dataNetboxJSONWirelessWirelessLinksList() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the wireless_wireless_links_list Netbox endpoint.",
-		Read:        dataNetboxJSONWirelessWirelessLinksListRead,
+		ReadContext: dataNetboxJSONWirelessWirelessLinksListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -29,7 +31,7 @@ func dataNetboxJSONWirelessWirelessLinksList() *schema.Resource {
 	}
 }
 
-func dataNetboxJSONWirelessWirelessLinksListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSONWirelessWirelessLinksListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := wireless.NewWirelessWirelessLinksListParams()
@@ -38,7 +40,7 @@ func dataNetboxJSONWirelessWirelessLinksListRead(d *schema.ResourceData, m inter
 
 	list, err := client.Wireless.WirelessWirelessLinksList(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)

--- a/netbox/data_netbox_tenancy_contact.go
+++ b/netbox/data_netbox_tenancy_contact.go
@@ -1,9 +1,10 @@
 package netbox
 
 import (
-	"fmt"
+	"context"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
@@ -12,7 +13,7 @@ import (
 
 func dataNetboxTenancyContact() *schema.Resource {
 	return &schema.Resource{
-		Read: dataNetboxTenancyContactRead,
+		ReadContext: dataNetboxTenancyContactRead,
 
 		Schema: map[string]*schema.Schema{
 			"content_type": {
@@ -28,7 +29,7 @@ func dataNetboxTenancyContact() *schema.Resource {
 	}
 }
 
-func dataNetboxTenancyContactRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxTenancyContactRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	name := d.Get("name").(string)
@@ -37,14 +38,14 @@ func dataNetboxTenancyContactRead(d *schema.ResourceData, m interface{}) error {
 
 	list, err := client.Tenancy.TenancyContactsList(p, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if *list.Payload.Count < 1 {
-		return fmt.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	} else if *list.Payload.Count > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
+		return diag.Errorf("Your query returned more than one result. " +
 			"Please try a more specific search criteria.")
 	}
 

--- a/netbox/data_netbox_tenancy_contact_group.go
+++ b/netbox/data_netbox_tenancy_contact_group.go
@@ -1,9 +1,10 @@
 package netbox
 
 import (
-	"fmt"
+	"context"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
@@ -12,7 +13,7 @@ import (
 
 func dataNetboxTenancyContactGroup() *schema.Resource {
 	return &schema.Resource{
-		Read: dataNetboxTenancyContactGroupRead,
+		ReadContext: dataNetboxTenancyContactGroupRead,
 
 		Schema: map[string]*schema.Schema{
 			"content_type": {
@@ -28,7 +29,7 @@ func dataNetboxTenancyContactGroup() *schema.Resource {
 	}
 }
 
-func dataNetboxTenancyContactGroupRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxTenancyContactGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	slug := d.Get("slug").(string)
@@ -37,14 +38,14 @@ func dataNetboxTenancyContactGroupRead(d *schema.ResourceData, m interface{}) er
 
 	list, err := client.Tenancy.TenancyContactGroupsList(p, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if *list.Payload.Count < 1 {
-		return fmt.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	} else if *list.Payload.Count > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
+		return diag.Errorf("Your query returned more than one result. " +
 			"Please try a more specific search criteria.")
 	}
 

--- a/netbox/data_netbox_tenancy_tenant.go
+++ b/netbox/data_netbox_tenancy_tenant.go
@@ -1,10 +1,11 @@
 package netbox
 
 import (
-	"fmt"
+	"context"
 	"regexp"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
@@ -13,7 +14,7 @@ import (
 
 func dataNetboxTenancyTenant() *schema.Resource {
 	return &schema.Resource{
-		Read: dataNetboxTenancyTenantRead,
+		ReadContext: dataNetboxTenancyTenantRead,
 
 		Schema: map[string]*schema.Schema{
 			"content_type": {
@@ -31,7 +32,7 @@ func dataNetboxTenancyTenant() *schema.Resource {
 	}
 }
 
-func dataNetboxTenancyTenantRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxTenancyTenantRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	slug := d.Get("slug").(string)
@@ -40,14 +41,14 @@ func dataNetboxTenancyTenantRead(d *schema.ResourceData, m interface{}) error {
 
 	list, err := client.Tenancy.TenancyTenantsList(p, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if *list.Payload.Count < 1 {
-		return fmt.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	} else if *list.Payload.Count > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
+		return diag.Errorf("Your query returned more than one result. " +
 			"Please try a more specific search criteria.")
 	}
 

--- a/netbox/data_netbox_tenancy_tenant_group.go
+++ b/netbox/data_netbox_tenancy_tenant_group.go
@@ -1,10 +1,11 @@
 package netbox
 
 import (
-	"fmt"
+	"context"
 	"regexp"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
@@ -13,7 +14,7 @@ import (
 
 func dataNetboxTenancyTenantGroup() *schema.Resource {
 	return &schema.Resource{
-		Read: dataNetboxTenancyTenantGroupRead,
+		ReadContext: dataNetboxTenancyTenantGroupRead,
 
 		Schema: map[string]*schema.Schema{
 			"content_type": {
@@ -31,8 +32,8 @@ func dataNetboxTenancyTenantGroup() *schema.Resource {
 	}
 }
 
-func dataNetboxTenancyTenantGroupRead(d *schema.ResourceData,
-	m interface{}) error {
+func dataNetboxTenancyTenantGroupRead(ctx context.Context, d *schema.ResourceData,
+	m interface{}) diag.Diagnostics {
 
 	client := m.(*netboxclient.NetBoxAPI)
 
@@ -42,14 +43,14 @@ func dataNetboxTenancyTenantGroupRead(d *schema.ResourceData,
 
 	list, err := client.Tenancy.TenancyTenantGroupsList(p, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if *list.Payload.Count < 1 {
-		return fmt.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	} else if *list.Payload.Count > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
+		return diag.Errorf("Your query returned more than one result. " +
 			"Please try a more specific search criteria.")
 	}
 

--- a/netbox/data_netbox_tenancy_tenant_role.go
+++ b/netbox/data_netbox_tenancy_tenant_role.go
@@ -1,10 +1,11 @@
 package netbox
 
 import (
-	"fmt"
+	"context"
 	"regexp"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
@@ -13,7 +14,7 @@ import (
 
 func dataNetboxTenancyContactRole() *schema.Resource {
 	return &schema.Resource{
-		Read: dataNetboxTenancyContactRoleRead,
+		ReadContext: dataNetboxTenancyContactRoleRead,
 
 		Schema: map[string]*schema.Schema{
 			"content_type": {
@@ -31,8 +32,8 @@ func dataNetboxTenancyContactRole() *schema.Resource {
 	}
 }
 
-func dataNetboxTenancyContactRoleRead(d *schema.ResourceData,
-	m interface{}) error {
+func dataNetboxTenancyContactRoleRead(ctx context.Context, d *schema.ResourceData,
+	m interface{}) diag.Diagnostics {
 
 	client := m.(*netboxclient.NetBoxAPI)
 
@@ -42,14 +43,14 @@ func dataNetboxTenancyContactRoleRead(d *schema.ResourceData,
 
 	list, err := client.Tenancy.TenancyContactRolesList(p, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if *list.Payload.Count < 1 {
-		return fmt.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	} else if *list.Payload.Count > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
+		return diag.Errorf("Your query returned more than one result. " +
 			"Please try a more specific search criteria.")
 	}
 

--- a/netbox/data_netbox_virtualization_cluster.go
+++ b/netbox/data_netbox_virtualization_cluster.go
@@ -1,9 +1,10 @@
 package netbox
 
 import (
-	"fmt"
+	"context"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	netboxclient "github.com/smutel/go-netbox/netbox/client"
@@ -12,7 +13,7 @@ import (
 
 func dataNetboxVirtualizationCluster() *schema.Resource {
 	return &schema.Resource{
-		Read: dataNetboxVirtualizationClusterRead,
+		ReadContext: dataNetboxVirtualizationClusterRead,
 
 		Schema: map[string]*schema.Schema{
 			"content_type": {
@@ -28,8 +29,8 @@ func dataNetboxVirtualizationCluster() *schema.Resource {
 	}
 }
 
-func dataNetboxVirtualizationClusterRead(d *schema.ResourceData,
-	m interface{}) error {
+func dataNetboxVirtualizationClusterRead(ctx context.Context, d *schema.ResourceData,
+	m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	name := d.Get("name").(string)
@@ -39,14 +40,14 @@ func dataNetboxVirtualizationClusterRead(d *schema.ResourceData,
 
 	list, err := client.Virtualization.VirtualizationClustersList(resource, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if *list.Payload.Count < 1 {
-		return fmt.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	} else if *list.Payload.Count > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
+		return diag.Errorf("Your query returned more than one result. " +
 			"Please try a more specific search criteria.")
 	}
 

--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -1,12 +1,14 @@
 package netbox
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
 
 	runtimeclient "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/smutel/go-netbox/netbox/client"
 )
@@ -169,11 +171,11 @@ func Provider() *schema.Provider {
 			"netbox_virtualization_interface":   resourceNetboxVirtualizationInterface(),
 			"netbox_virtualization_vm":          resourceNetboxVirtualizationVM(),
 		},
-		ConfigureFunc: configureProvider,
+		ConfigureContextFunc: configureProvider,
 	}
 }
 
-func configureProvider(d *schema.ResourceData) (interface{}, error) {
+func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	url := d.Get("url").(string)
 	basepath := d.Get("basepath").(string)
 	token := d.Get("token").(string)

--- a/utils/generateJsonDatasources
+++ b/utils/generateJsonDatasources
@@ -94,7 +94,7 @@ import (
 func dataNetboxJSON${SECTION}${ITEM}List() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get json output from the ${ENDPOINT}_list Netbox endpoint.",
-		Read:        dataNetboxJSON${SECTION}${ITEM}ListRead,
+		ReadContext: dataNetboxJSON${SECTION}${ITEM}ListRead,
 
 		Schema: map[string]*schema.Schema{
 			"limit": {
@@ -112,7 +112,7 @@ func dataNetboxJSON${SECTION}${ITEM}List() *schema.Resource {
 	}
 }
 
-func dataNetboxJSON${SECTION}${ITEM}ListRead(d *schema.ResourceData, m interface{}) error {
+func dataNetboxJSON${SECTION}${ITEM}ListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*netboxclient.NetBoxAPI)
 
 	params := ${SECTION,}.New${SECTION}${ITEM}ListParams()
@@ -121,7 +121,7 @@ func dataNetboxJSON${SECTION}${ITEM}ListRead(d *schema.ResourceData, m interface
 
 	list, err := client.${SECTION}.${SECTION}${ITEM}List(params, nil)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	j, _ := json.Marshal(list.Payload.Results)


### PR DESCRIPTION
Fixes: #135

This PR is a simple search and replace. Deprecated fields are replaced and functions are updated to new signatures.

The following replacements were done:
(Read,Create,Update,Delete) -> (Read,Create,Update,Delete)Context
`return err` -> `return diag.FromErr(err)`
`fmt.Errrorf` -> `diag.Errorf`
`error` -> `diag.Diagnostics` in the relevant functions
Add `ctx context.Context` to function signatures

TODO:
Remove deprecated Exists-Functions and update Read-Function to use `d.SetId("")` if the resource does not exist. This needs proper error handling in go-netbox, which depends on https://github.com/netbox-community/netbox/issues/4986
