### PR TITLE
feat: Allow prefix and ip to be dynamically assigned

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -219,6 +219,14 @@ resource "netbox_ipam_prefix" "prefix_test" {
   }
 }
 
+resource "netbox_ipam_prefix" "dynamic_prefix_test" {
+  parent_prefix {
+    prefix = netbox_ipam_prefix.prefix_test.id
+    prefix_length = 26
+  } 
+  description = "Dynamic prefix created by terraform"
+}
+
 resource "netbox_ipam_ip_range" "range_test" {
   start_address = "192.168.56.1/24"
   end_address = "192.168.56.100/24"
@@ -333,6 +341,18 @@ resource "netbox_ipam_ip_addresses" "ip_test" {
     type = "multiple"
     value = "0,1"
   }
+}
+
+resource "netbox_ipam_ip_addresses" "dynamic_ip_from_prefix" {
+  prefix = netbox_ipam_prefix.dynamic_prefix_test.id
+  description = "Dynamic IP in dynamic prefix created by terraform"
+  status = "active"
+}
+
+resource "netbox_ipam_ip_addresses" "dynamic_ip_from_ip_range" {
+  ip_range = netbox_ipam_ip_range.range_test.id
+  description = "Dynamic IP in IP range created by terraform"
+  status = "active"
 }
 
 data "netbox_virtualization_cluster" "cluster_test" {

--- a/examples/resources/netbox_ipam_ip_addresses/resource.tf
+++ b/examples/resources/netbox_ipam_ip_addresses/resource.tf
@@ -50,3 +50,15 @@ resource "netbox_ipam_ip_addresses" "ip_test" {
     value = "0,1"
   }
 }
+
+resource "netbox_ipam_ip_addresses" "dynamic_ip_from_prefix" {
+  prefix = netbox_ipam_prefix.dynamic_prefix_test.id
+  description = "Dynamic IP in dynamic prefix created by terraform"
+  status = "active"
+}
+
+resource "netbox_ipam_ip_addresses" "dynamic_ip_from_ip_range" {
+  ip_range = netbox_ipam_ip_range.range_test.id
+  description = "Dynamic IP in IP range created by terraform"
+  status = "active"
+}

--- a/examples/resources/netbox_ipam_prefix/resource.tf
+++ b/examples/resources/netbox_ipam_prefix/resource.tf
@@ -53,3 +53,11 @@ resource "netbox_ipam_prefix" "prefix_test" {
     value = "0,1"
   }
 }
+
+resource "netbox_ipam_prefix" "dynamic_prefix_test" {
+  parent_prefix {
+    prefix = netbox_ipam_prefix.prefix_test.id
+    prefix_length = 26
+  } 
+  description = "Dynamic prefix created by terraform"
+}

--- a/main.go
+++ b/main.go
@@ -14,16 +14,16 @@ import (
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
 func main() {
-    var debug bool
+	var debug bool
 
-    flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
-    flag.Parse()
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
 
-    opts := &plugin.ServeOpts{
-        Debug:        debug,
-        ProviderAddr: "registry.terraform.io/smutel/netbox",
-        ProviderFunc: netbox.Provider,
-    }
+	opts := &plugin.ServeOpts{
+		Debug:        debug,
+		ProviderAddr: "registry.terraform.io/smutel/netbox",
+		ProviderFunc: netbox.Provider,
+	}
 
-    plugin.Serve(opts)
+	plugin.Serve(opts)
 }

--- a/netbox/util.go
+++ b/netbox/util.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	netboxclient "github.com/smutel/go-netbox/v3/netbox/client"
+	"github.com/smutel/go-netbox/v3/netbox/client/ipam"
 	"github.com/smutel/go-netbox/v3/netbox/client/virtualization"
 	"github.com/smutel/go-netbox/v3/netbox/models"
 )
@@ -271,4 +272,40 @@ func convertURIContentType(uri strfmt.URI) string {
 
 	contentType := firstLevel + "." + secondLevel
 	return contentType
+}
+
+func getNewAvailableIPForIPRange(client *netboxclient.NetBoxAPI, id int64) (*models.IPAddress, error) {
+	params := ipam.NewIpamIPRangesAvailableIpsCreateParams().WithID(id)
+	params.Data = []*models.WritableAvailableIP{
+		{},
+	}
+	list, err := client.Ipam.IpamIPRangesAvailableIpsCreate(params, nil)
+	if err != nil {
+		return nil, err
+	}
+	return list.Payload[0], nil
+}
+
+func getNewAvailableIPForPrefix(client *netboxclient.NetBoxAPI, id int64) (*models.IPAddress, error) {
+	params := ipam.NewIpamPrefixesAvailableIpsCreateParams().WithID(id)
+	params.Data = []*models.WritableAvailableIP{
+		{},
+	}
+	list, err := client.Ipam.IpamPrefixesAvailableIpsCreate(params, nil)
+	if err != nil {
+		return nil, err
+	}
+	return list.Payload[0], nil
+}
+
+func getNewAvailablePrefix(client *netboxclient.NetBoxAPI, id int64, length int64) (*models.Prefix, error) {
+	params := ipam.NewIpamPrefixesAvailablePrefixesCreateParams().WithID(id)
+	params.Data = []*models.PrefixLength{
+		{PrefixLength: &length},
+	}
+	list, err := client.Ipam.IpamPrefixesAvailablePrefixesCreate(params, nil)
+	if err != nil {
+		return nil, err
+	}
+	return list.Payload[0], nil
 }


### PR DESCRIPTION
Fixes #45 

This PR changes address and prefix to allow for automatic assignment.

Two caveats:
- Schema can not be validated with plan, since AtLeastOneOf does not support optional attributes. See https://github.com/hashicorp/terraform-plugin-sdk/issues/705. I don't know if this can be improved.
- Generation is not necessarily in order. Creating multiple prefixes at once will result in random ordering.

This PR needs https://github.com/smutel/go-netbox/pull/41 to be merged into go-netbox. After merging the lint failure should be gone.