### PR TITLE
fix: Prevent panic if vcpus is null

### DIFF
--- a/netbox/resource_netbox_virtualization_vm.go
+++ b/netbox/resource_netbox_virtualization_vm.go
@@ -175,10 +175,6 @@ func resourceNetboxVirtualizationVMCreate(ctx context.Context, d *schema.Resourc
 	tenantID := int64(d.Get("tenant_id").(int))
 	vcpus := d.Get("vcpus").(string)
 
-	if !strings.Contains(vcpus, ".") {
-		vcpus = vcpus + ".00"
-	}
-
 	newResource := &models.WritableVirtualMachineWithConfigContext{
 		Cluster:      &clusterID,
 		Comments:     comments,
@@ -338,7 +334,13 @@ func resourceNetboxVirtualizationVMRead(ctx context.Context, d *schema.ResourceD
 				}
 			}
 
-			if err = d.Set("vcpus", fmt.Sprintf("%v", *resource.Vcpus)); err != nil {
+			var vcpus string
+			if resource.Vcpus == nil {
+				vcpus = ""
+			} else {
+				vcpus = fmt.Sprintf("%v", *resource.Vcpus)
+			}
+			if err = d.Set("vcpus", vcpus); err != nil {
 				return diag.FromErr(err)
 			}
 
@@ -419,7 +421,7 @@ func resourceNetboxVirtualizationVMUpdate(ctx context.Context, d *schema.Resourc
 		params.Tenant = &tenantID
 	}
 
-	if d.HasChange("vcpus") {
+	if _, ok := d.GetOk("vcpus"); d.HasChange("vcpus") && ok {
 		vcpus := d.Get("vcpus").(string)
 
 		if !strings.Contains(vcpus, ".") {


### PR DESCRIPTION
Fixes: #82 

Creating a VM without vcpus did not work because the addition of ".00" prevented the latter check for "" from working.
This resulted in sending `"vpus": 0` which is not allowed in netbox.

Additionally a read of a VM without vcpus failed with a panic because netbox sends null as value for vcpus.

Setting vcpus back to null does not work because of limitations in go-swagger or the json library in go. See the primary_ip issue. This is currently silently ignored in the Update.