### PR TITLE
ci: Fix go fmt command with sub-dirrectories

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Go fmt
         run: |
           cd "$(dirname $GITHUB_WORKSPACE)/src/github.com/smutel/terraform-provider-netbox"
-          go fmt netbox/*
+          find . -name "*.go" -exec go fmt {} \;
         shell: bash
 
       - name: Go generate


### PR DESCRIPTION
Go files are now in several sub-directories in the netbox folder.