### PR TITLE
fix: Increase size of tenant name/desc/slug

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.19.x' ]
+        go: [ '1.20.x' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.19.x' ]
+        go: [ '1.20.x' ]
     steps:
       - name: Check conventional commits in PR
         uses: Namchee/conventional-pr@v0.12.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.19.x' ]
+        go: [ '1.20.x' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3.0.2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Terraform provider for [Netbox.](https://netbox.readthedocs.io/en/stable/)
 
 * A libc library like libc6-compat or libc-utils
 * General developer tools like make, bash, ... (to build the provider)
-* Go 1.19 minimum (to build the provider)
+* Go 1.20 minimum (to build the provider)
 * Terraform (to use the provider)
 
 ## Compatibility with Netbox

--- a/netbox/tenancy/data_netbox_tenancy_tenant.go
+++ b/netbox/tenancy/data_netbox_tenancy_tenant.go
@@ -26,8 +26,8 @@ func DataNetboxTenancyTenant() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringMatch(
-					regexp.MustCompile("^[-a-zA-Z0-9_]{1,50}$"),
-					"Must be like ^[-a-zA-Z0-9_]{1,50}$"),
+					regexp.MustCompile("^[-a-zA-Z0-9_]{1,100}$"),
+					"Must be like ^[-a-zA-Z0-9_]{1,100}$"),
 			},
 		},
 	}

--- a/netbox/tenancy/resource_netbox_tenancy_tenant.go
+++ b/netbox/tenancy/resource_netbox_tenancy_tenant.go
@@ -45,7 +45,7 @@ func ResourceNetboxTenancyTenant() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      nil,
-				ValidateFunc: validation.StringLenBetween(1, 100),
+				ValidateFunc: validation.StringLenBetween(1, 200),
 				Description:  "The description for this tenant (tenancy module).",
 			},
 			"tenant_group_id": {
@@ -57,15 +57,15 @@ func ResourceNetboxTenancyTenant() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 30),
+				ValidateFunc: validation.StringLenBetween(1, 100),
 				Description:  "The name for this tenant (tenancy module).",
 			},
 			"slug": {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringMatch(
-					regexp.MustCompile("^[-a-zA-Z0-9_]{1,50}$"),
-					"Must be like ^[-a-zA-Z0-9_]{1,50}$"),
+					regexp.MustCompile("^[-a-zA-Z0-9_]{1,100}$"),
+					"Must be like ^[-a-zA-Z0-9_]{1,100}$"),
 				Description: "The slug for this tenant (tenancy module).",
 			},
 			"tag": &tag.TagSchema,


### PR DESCRIPTION
Fixes #182 

- increased input validation for name and slugs for the Tenant to 100.
- increased the validation for the data source
- increased the validation on the description to match the API

Tested on netbox version `3.2.5` and also `3.4.5`