### PR TITLE
fix: Support FieldName with multiple underscores

### DIFF
--- a/netbox/internal/util/util.go
+++ b/netbox/internal/util/util.go
@@ -122,8 +122,8 @@ func FieldNameToStructName(k string) string {
 
 	split := strings.Split(k, "_")
 	k = split[0]
-	if len(split) > 1 {
-		r2 := []rune(split[1])
+	for i := 1; i < len(split); i++ {
+		r2 := []rune(split[i])
 		r2[0] = unicode.ToUpper(r2[0])
 		k = k + string(r2)
 	}


### PR DESCRIPTION
previously, any fields with more than one underscore would not be correctly converted:

> short_filter becomes:    shortFilter
> a_longer_filter becomes: aLonger

this change hopefully fixes that by looking for any amount of underscores rather than just one, so 'a_longer_filter' should now become 'aLongerFilter'.