### PR TITLE
fix: Restore import support for virtualization_vm_primary_ip

### DIFF
--- a/netbox/virtualization/resource_netbox_virtualization_vm_primary_ip.go
+++ b/netbox/virtualization/resource_netbox_virtualization_vm_primary_ip.go
@@ -335,6 +335,14 @@ func resourceNetboxVirtualizationVMPrimaryIPExists(d *schema.ResourceData,
 	client := m.(*netbox.APIClient)
 
 	resourceID := d.Get("virtualmachine_id").(int)
+	// When importing, ID is set, not virtualmachine_id
+	if resourceID == 0 {
+		id, err := strconv.ParseInt(d.Id(), util.Const10, util.Const32)
+		if err != nil {
+			return false, err
+		}
+		resourceID = int(id)
+	}
 	resourceID32, err := safecast.ToInt32(resourceID)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Fall back to d.Id() when virtualmachine_id is unset, which happens during import. This restores the fix from c17026d0, and regressed at some point.
Original issue: https://github.com/smutel/terraform-provider-netbox/issues/188